### PR TITLE
Allow configuration of buffer kind

### DIFF
--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -637,7 +637,8 @@ local function unstage()
   refresh_status()
 end
 
-local function create()
+local function create(kind)
+  kind = kind or 'tab'
   if status_buffer then
     status_buffer:focus()
     return
@@ -646,7 +647,7 @@ local function create()
   Buffer.create {
     name = "NeogitStatus",
     filetype = "NeogitStatus",
-    kind = "tab",
+    kind = kind,
     initialize = function(buffer)
       status_buffer = buffer
 


### PR DESCRIPTION
tl;dr: I want splits :)

With this change, a user can set the way in which the status buffer will
open by using the lua invocation directly like so:

`require'neogit.status'.create('split')`

Defaults to 'tab' to preserve old behavior. No argument sanitization, but it's also undocumented, so eh. Not sure if we should add a specific command like `SNeogit` or just document the lua api.