### PR TITLE
Display improvements to status buffer overview

### DIFF
--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -82,7 +82,9 @@ local status = {
       "status --porcelain=1 --branch",
       "stash list",
       "log --oneline @{upstream}..",
-      "log --oneline ..@{upstream}"
+      "log --oneline ..@{upstream}",
+      "log -1 --pretty=%B",
+      "log -1 --pretty=%B @{upstream}"
     }, false)
 
     local result = {
@@ -93,6 +95,12 @@ local status = {
       stashes = git.stash.parse(outputs[2]),
       unpulled = util.map(outputs[4], function(x) return { name = x } end),
       unmerged = util.map(outputs[3], function(x) return { name = x } end),
+      HEAD = {
+        message = outputs[5][1]
+      },
+      upstream = {
+        message = outputs[6][1]
+      },
       branch = "",
       remote = ""
     }

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -95,14 +95,11 @@ local status = {
       stashes = git.stash.parse(outputs[2]),
       unpulled = util.map(outputs[4], function(x) return { name = x } end),
       unmerged = util.map(outputs[3], function(x) return { name = x } end),
-      HEAD = {
-        message = outputs[5][1]
+      head = {
+        message = outputs[5][1],
+        branch = ""
       },
-      upstream = {
-        message = outputs[6][1]
-      },
-      branch = "",
-      remote = ""
+      upstream = nil
     }
 
     local function insert_change(list, marker, name)
@@ -122,8 +119,13 @@ local status = {
 
       if marker == "##" then
         local tokens = vim.split(details, "...", true)
-        result.branch = tokens[1]
-        result.remote = tokens[2] and vim.split(tokens[2], " ", true)[1] or result.branch
+        result.head.branch = tokens[1]
+        if tokens[2] ~= nil then
+          result.upstream = {
+            branch = vim.split(tokens[2], " ", true)[1],
+            message = outputs[6][1]
+          }
+        end
       elseif marker == "??" then
         insert_change(result.untracked_files, "A", details)
       elseif marker == "UU" then

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -152,11 +152,10 @@ local function display_status()
   end
 
   locations = {}
-
   local line_idx = 3
   local output = {
-    "Head: " .. status.branch,
-    "Push: " .. status.remote,
+    "Head: " .. status.branch .. " " .. status.HEAD.message,
+    "Push: " .. status.remote .. " " .. (status.upstream.message or ''),
     ""
   }
 
@@ -310,11 +309,17 @@ local function refresh_status()
     return
   end
 
-  for _,x in pairs(status) do
-    if type(x) == "table" then
-      for _,i in pairs(x) do
-        i.diff_open = false
-      end
+  for _,x in ipairs({
+    'untracked_files',
+    'unstaged_changes',
+    'unmerged_changes',
+    'staged_changes',
+    'unpulled',
+    'unmerged',
+    'stashes'
+  }) do
+    for _,i in ipairs(status[x]) do
+      i.diff_open = false
     end
   end
 

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -152,12 +152,15 @@ local function display_status()
   end
 
   locations = {}
-  local line_idx = 3
+  local line_idx = 2
   local output = {
-    "Head: " .. status.branch .. " " .. status.HEAD.message,
-    "Push: " .. status.remote .. " " .. (status.upstream.message or ''),
-    ""
+    "Head: " .. status.head.branch .. " " .. status.head.message
   }
+  if status.upstream ~= nil then
+    line_idx = line_idx + 1
+    table.insert(output, "Push: " .. status.upstream.branch .. " " .. status.upstream.message)
+  end
+  table.insert(output, "")
 
   local function write(str)
     table.insert(output, str)

--- a/syntax/NeogitStatus.vim
+++ b/syntax/NeogitStatus.vim
@@ -3,8 +3,9 @@ if exists("b:current_syntax")
 endif
 
 syn match NeogitObjectId /^[a-z0-9]\{7} /
-syn match NeogitBranch /.*/ contained
-syn match NeogitRemote /[a-zA-Z/]/ contained
+syn match NeogitCommitMessage /.*/ contained
+syn match NeogitBranch /\S\+/ contained nextgroup=NeogitCommitMessage
+syn match NeogitRemote /\S\+/ contained nextgroup=NeogitCommitMessage
 syn match NeogitDiffAdd /.*/ contained
 syn match NeogitDiffDelete /.*/ contained
 syn match NeogitStash /stash@{[0-9]*}\ze/
@@ -20,8 +21,8 @@ for section in b:sections
   execute 'hi def link Neogit' . id . ' Function'
 endfor
 
-syn region NeogitHeadRegion start=/^Head: \zs.*/ end=/$/ contains=NeogitBranch
-syn region NeogitPushRegion start=/^Push: \zs.*/ end=/$/ contains=NeogitRemote
+syn region NeogitHeadRegion start=/^Head: \zs/ end=/$/ contains=NeogitBranch
+syn region NeogitPushRegion start=/^Push: \zs/ end=/$/ contains=NeogitRemote
 syn region NeogitUnmergedIntoRegion start=/^Unmerged into .*/ end=/$/ contains=NeogitRemote,NeogitUnmergedInto
 syn region NeogitUnpulledFromRegion start=/^Unpulled from .*/ end=/$/ contains=NeogitRemote,NeogitUnpulledFrom
 syn region NeogitDiffAddRegion start=/^+.*$/ end=/$/ contains=NeogitDiffAdd


### PR DESCRIPTION
Adds the commit message of the current commit of head and upstream to the status buffer and only displays upstream when there's actually an upstream configured.

Had to switch highlighting of the head and upstream lines to the highlighting api, because I don't know how to do the current highlighting with :syntax. The highlights may need to be cleaned up on refresh, but I wasn't able to actually refresh an open status buffer with a changed branch and I didn't want to implement blind.