### PR TITLE
Add shortcut to discard changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ P - open push popup
 
 p - open pull popup
 
+x - discard changes (also supports discarding hunks)
+
 ## Contextual Highlighting
 
 The colors for contextual highlighting are defined with these highlight groups:

--- a/lua/neogit/lib/git.lua
+++ b/lua/neogit/lib/git.lua
@@ -1,7 +1,31 @@
+local cli = require("neogit.lib.git.cli")
+
+local function command_with_files(name, params)
+    local args = params.args or {}
+    local files = params.files or {}
+
+    local cmd = name .. " " .. table.concat(args, " ")
+    if #files > 0 then
+      cmd = cmd .. ' -- ' .. table.concat(files, " ")
+    end
+
+    return cmd
+end
+
 return {
   status = require("neogit.lib.git.status"),
   stash = require("neogit.lib.git.stash"),
   log = require("neogit.lib.git.log"),
-  cli = require("neogit.lib.git.cli"),
+  cli = cli,
   diff = require("neogit.lib.git.diff"),
+
+  apply = function (patch, parameters)
+    cli.run_with_stdin(string.format('apply %s', parameters), patch)
+  end,
+  checkout = function (params)
+    cli.run(command_with_files('checkout', params))
+  end,
+  reset = function (params)
+    cli.run(command_with_files('reset', params))
+  end
 }

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -706,7 +706,8 @@ local function discard()
     local on_hunk = line_is_hunk(vim.fn.getline('.'))
 
     if on_hunk then
-      local _, lines = get_current_hunk_of_item(item)
+      local hunk, lines = get_current_hunk_of_item(item)
+      lines[1] = string.format('@@ -%d,%d +%d,%d @@', hunk.index_from, hunk.index_len, hunk.index_from, hunk.disk_len)
       local diff = table.concat(lines, "\n")
       diff = table.concat({'--- a/'..item.name, '+++ b/'..item.name, diff, ""}, "\n")
       if section.name == "staged_changes" then


### PR DESCRIPTION
Add a new command `x` that will discard changes under the cursor,
after user confirmation. Works on hunks, unstaged and staged files.
Does not currently work on untracked files due to a bug in hunk
detection firing on those.
Does not currently work on whole sections or selections.