### PR TITLE
test: PoC Unit Test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	nvim --headless --noplugin -c "lua require(\"plenary.test_harness\").test_directory_command('tests/ {minimal_init = \"tests/minimal-init.nvim\"}')"

--- a/README.md
+++ b/README.md
@@ -72,3 +72,14 @@ You can override them to fit your colorscheme by creating a `syntax/NeogitStatus
 The todo file does not represent ALL of the missing features. This file just shows the features which I noticed were missing and I have to implement. This file will grow in the future.
 
 [TODO](./todo.md)
+
+## Testing
+
+Assure that you have [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) 
+installed as a plugin for your neovim instance. Afterwards, run `make test`
+to run the unit test suite.
+
+Plenary uses it's own port of busted and a bundled luassert, so consult their
+code and the respective [busted](http://olivinelabs.com/busted/) and 
+[luassert](http://olivinelabs.com/busted/#asserts) docs for what methods are 
+available.

--- a/tests/minimal-init.nvim
+++ b/tests/minimal-init.nvim
@@ -1,0 +1,2 @@
+set rtp+=.
+runtime plugin/neogit.vim

--- a/tests/poc_spec.lua
+++ b/tests/poc_spec.lua
@@ -1,0 +1,23 @@
+local eq = assert.are.same
+
+describe('proof of concept', function ()
+  it('should work', function ()
+    assert(true)
+  end)
+
+  it('should have access to vim global', function ()
+    assert.is_not_nil(vim)
+  end)
+
+  it('should be able to interact with vim', function ()
+    vim.cmd("let g:val = v:true")
+    eq(true, vim.g.val)
+  end)
+
+  it('has access to buffers', function ()
+    vim.cmd('Neogit')
+    -- 1 is most likely the initial buffer nvim openes when starting?
+    -- 2 is the neogit buffer just opened
+    eq({ 1, 2 }, vim.api.nvim_list_bufs())
+  end)
+end)


### PR DESCRIPTION
Closes #32 

Setup unit tests using `plenary.nvim`'s test harness. Plenary is
expected to be installed as a plugin on the neovim instance you're
running your tests on.

I opted out of adding plenary to the repository since git plugins are usually directly pulled from repositories and including plenary into that seems wrong. So I just expected it to be installed already.

I included a small sample test suite to show what's possible, but no actually meaningful tests yet.