### PR TITLE
fix(#43): set content_buffer for floating status as listed

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -183,7 +183,7 @@ function Buffer.create(config)
     local col = col + 1
     local row = row + 1
 
-    local content_buffer = vim.api.nvim_create_buf(false, true)
+    local content_buffer = vim.api.nvim_create_buf(true, true)
     local content_window = vim.api.nvim_open_win(content_buffer, true, {
       relative = 'editor',
       width = width,


### PR DESCRIPTION
The `:bufdo` command can only operate on listed buffers. Since we use that
to target the status buffer to create folds, we need to make sure that
buffer is listed.

Closes #43