### PR TITLE
Keep commit message on commit failure and more

### DIFF
--- a/lua/neogit/async/uv.lua
+++ b/lua/neogit/async/uv.lua
@@ -1,0 +1,23 @@
+local uv = vim.loop
+local a = require('neogit.async')
+
+local wrapper = setmetatable({}, {
+  __index = function (tbl, action)
+    if uv[action] then
+      return a.wrap(uv[action])
+    end
+
+    return nil
+  end
+})
+
+wrapper.read_file = a.sync(function (file)
+  local err, fd = a.wait(wrapper.fs_open(file, 'r', 438))
+  if err then return nil end
+  local _, stat = a.wait(wrapper.fs_fstat(fd))
+  local _, data = a.wait(wrapper.fs_read(fd, stat.size, 0))
+  a.wait(wrapper.fs_close(fd))
+  return data
+end)
+
+return wrapper

--- a/lua/neogit/lib/git.lua
+++ b/lua/neogit/lib/git.lua
@@ -7,18 +7,4 @@ return {
   log = require("neogit.lib.git.log"),
   cli = cli,
   diff = require("neogit.lib.git.diff"),
-
-  apply = a.sync(function (patch, parameters)
-    a.wait(cli.exec('apply', parameters, nil, patch))
-  end),
-  checkout = a.sync(function (params)
-    local files = params.files
-    table.insert(files, 1, '--')
-    a.wait(cli.exec('checkout', files))
-  end),
-  reset = a.sync(function (params)
-    local files = params.files
-    table.insert(files, 1, '--')
-    a.wait(cli.exec('reset', files))
-  end)
 }

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -66,7 +66,8 @@ local configurations = {
   }),
   commit = config({
     flags = {
-      amend = '--amend'
+      amend = '--amend',
+      no_edit = '--no-edit'
     },
     options = {
       commit_message_file = '--file'

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -25,6 +25,9 @@ local configurations = {
   log = config({
     flags = {
       oneline = "--oneline",
+      branches = "--branches",
+      remotes = "--remotes",
+      all = "--all"
     },
     options = {
       pretty = "--pretty",

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -1,14 +1,88 @@
 local notif = require("neogit.lib.notification")
-local Job = require("neogit.lib.job")
-local util = require("neogit.lib.util")
 local a = require('neogit.async')
 local process = require('neogit.process')
 local split = require('neogit.lib.util').split
 
+local function config(setup)
+  setup = setup or {}
+  setup.flags = setup.flags or {}
+  setup.options = setup.options or {}
+  setup.aliases = setup.aliases or {}
+  return setup
+end
+
+local configurations = {
+  status = config({
+    flags = {
+      short = "-s",
+      branch = "-b",
+      verbose = "-v"
+    },
+    options = {
+      porcelain = "--porcelain",
+    },
+  }),
+  log = config({
+    flags = {
+      oneline = "--oneline",
+    },
+    options = {
+      pretty = "--pretty",
+      max_count = "--max-count"
+    },
+    aliases = {
+      for_range = function (tbl)
+        return function (range)
+          return tbl.args(range)
+        end
+      end
+    }
+  }),
+  diff = config({
+    flags = {
+      cached = '--cached',
+    },
+  }),
+  stash = config({ }),
+  reset = config({ }),
+  checkout = config({ }),
+  apply = config({
+    flags = {
+      cached = '--cached',
+      reverse = '--reverse',
+      index = '--index'
+    },
+    aliases = {
+      with_patch = function (tbl)
+        return tbl.input
+      end
+    }
+  }),
+  add = config({
+    flags = {
+      update = '-u',
+      all = '-A'
+    },
+  }),
+  commit = config({
+    flags = {
+      amend = '--amend'
+    },
+    options = {
+      commit_message_file = '--file'
+    }
+  }),
+  push = config({ }),
+  pull = config({
+    flags = {
+      no_commit = '--no-commit'
+    },
+  })
+}
+
 local git_root = a.sync(function()
   return vim.trim(a.wait(process.spawn({cmd = 'git', args = {'rev-parse', '--show-toplevel'}})))
 end)
-
 
 local history = {}
 
@@ -55,25 +129,163 @@ local exec = a.sync(function(cmd, args, cwd, stdin)
   return result, code, errors
 end)
 
-local cli = {
-  exec = exec,
-  exec_all = a.sync(function(cmds, cwd)
-    if #cmds == 0 then return end
+local k_state = {}
+local k_config = {}
+local k_command = {}
 
-    local processes = {}
-    local root = cwd or a.wait(git_root())
-
-    if root == nil or root == "" then
-      return nil
+local mt_builder = {
+  __index = function (tbl, action)
+    if action == 'args' or action == 'arguments' then
+      return function (...)
+        for _, v in ipairs({...}) do
+          table.insert(tbl[k_state].arguments, v)
+        end
+        return tbl
+      end
     end
 
-    for _, cmd in ipairs(cmds) do
-      table.insert(processes, exec(cmd.cmd, cmd.args, root))
+    if action == 'files' or action == 'paths' then
+      return function (...)
+        for _, v in ipairs({...}) do
+          table.insert(tbl[k_state].files, v)
+        end
+        return tbl
+      end
+    end
+
+    if action == 'input' or action == 'stdin' then
+      return function (value)
+        tbl[k_state].input = value
+        return tbl
+      end
+    end
+
+    if action == 'cwd' then
+      return function (cwd)
+        tbl[k_state].cwd = cwd
+        return tbl
+      end
+    end
+
+    if tbl[k_config].flags[action] then
+      table.insert(tbl[k_state].options, tbl[k_config].flags[action])
+      return tbl
+    end
+
+    if tbl[k_config].options[action] then
+      return function (value)
+        if value then
+          table.insert(tbl[k_state].options, string.format("%s=%s", tbl[k_config].options[action], value))
+        else
+          table.insert(tbl[k_state].options, tbl[k_config].options[action])
+        end
+        return tbl
+      end
+    end
+
+    if tbl[k_config].aliases[action] then
+      return tbl[k_config].aliases[action](tbl, tbl[k_state])
+    end
+
+    error("unknown field: " .. action)
+  end,
+  __tostring = function (tbl)
+    return string.format('git %s %s %s -- %s',
+      tbl[k_command],
+      table.concat(tbl[k_state].options, ' '),
+      table.concat(tbl[k_state].arguments, ' '),
+      table.concat(tbl[k_state].files, ' '))
+  end,
+  __call = function (tbl, ...)
+    return tbl.call(...)
+  end
+}
+
+local function new_builder(subcommand)
+  local configuration = configurations[subcommand]
+  if not configuration then error("Command not found") end
+
+  local state = {
+    options = {},
+    arguments = {},
+    files = {},
+    input = nil,
+    cwd = nil
+  }
+
+  return setmetatable({
+    [k_state] = state,
+    [k_config] = configuration,
+    [k_command] = subcommand,
+    call = a.sync(function ()
+      local args = {}
+      for _,o in ipairs(state.options) do table.insert(args, o) end
+      for _,a in ipairs(state.arguments) do table.insert(args, a) end
+      table.insert(args, '--')
+      for _,f in ipairs(state.files) do table.insert(args, f) end
+
+      return a.wait(exec(subcommand, args, state.cwd, state.input))
+    end)
+  }, mt_builder)
+end
+
+local function new_parallel_builder(calls)
+  local state = {
+    calls = calls,
+    cwd = nil
+  }
+
+  local call = a.sync(function ()
+    if #state.calls == 0 then return end
+
+    if not state.cwd then
+      state.cwd = a.wait(git_root())
+    end
+    if not state.cwd or state.cwd == "" then return end
+
+    for _,c in ipairs(state.calls) do
+      c.cwd(state.cwd)
+    end
+
+    local processes = {}
+    for _,c in ipairs(state.calls) do
+      table.insert(processes, c())
     end
 
     return a.wait_all(processes)
-  end),
-  history = history
+  end)
+
+  return setmetatable({
+    call = call
+  }, {
+    __index = function (tbl, action)
+      if action == 'cwd' then
+        return function (cwd)
+          state.cwd = cwd
+          return tbl
+        end
+      end
+    end,
+    __call = call
+  })
+end
+
+local meta = {
+  __index = function (tbl, key)
+    if configurations[key] then
+      return new_builder(key)
+    end
+
+    error("unknown field")
+  end
 }
+
+local cli = setmetatable({
+  history = history,
+  in_parallel = function(...)
+    local calls = {...}
+    return new_parallel_builder(calls)
+  end
+}, meta)
 
 return cli

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -67,6 +67,7 @@ local configurations = {
   commit = config({
     flags = {
       amend = '--amend',
+      only = '--only',
       no_edit = '--no-edit'
     },
     options = {

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -3,6 +3,7 @@ local Job = require("neogit.lib.job")
 local util = require("neogit.lib.util")
 local a = require('neogit.async')
 local process = require('neogit.process')
+local split = require('neogit.lib.util').split
 
 local git_root = a.sync(function()
   return vim.trim(a.wait(process.spawn({cmd = 'git', args = {'rev-parse', '--show-toplevel'}})))
@@ -44,8 +45,8 @@ local exec = a.sync(function(cmd, args, cwd, stdin)
   }))
   handle_new_cmd({
     cmd =  'git ' .. table.concat(args, ' '),
-    stdout = result ~= "" and vim.split(result, '\n') or {},
-    stderr = errors ~= "" and vim.split(errors, '\n') or {},
+    stdout = split(result, '\n'),
+    stderr = split(errors, '\n'),
     code = code,
     time = os.clock() - time
   }, true)

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -2,34 +2,37 @@ local cli = require("neogit.lib.git.cli")
 local util = require("neogit.lib.util")
 local a = require('neogit.async')
 
+local function parse_log(output)
+  output = vim.split(output, '\n')
+  local output_len = #output
+  local commits = {}
+
+  for i=1,output_len do
+    local level, hash, rest = output[i]:match("([| *]*)([a-zA-Z0-9]+) (.*)")
+    if level ~= nil then
+      local remote, message = rest:match("%((.-)%) (.*)")
+      if remote == nil then
+        message = rest
+      end
+
+      local commit = {
+        level = util.str_count(level, "|"),
+        hash = hash,
+        remote = remote or "",
+        message = message
+      }
+      table.insert(commits, commit)
+    end
+  end
+
+  return commits
+end
+
 return {
   list = a.sync(function(options)
-    options = vim.split(options, ' ')
-    table.insert(options, 1, '--oneline')
-
+    options = util.split(options, ' ')
     local output = a.wait(cli.log.oneline.args(unpack(options)).call())
-    output = vim.split(output, '\n')
-    local output_len = #output
-    local commits = {}
-
-    for i=1,output_len do
-      local level, hash, rest = output[i]:match("([| *]*)([a-zA-Z0-9]+) (.*)")
-      if level ~= nil then
-        local remote, message = rest:match("%((.-)%) (.*)")
-        if remote == nil then
-          message = rest
-        end
-
-        local commit = {
-          level = util.str_count(level, "|"),
-          hash = hash,
-          remote = remote or "",
-          message = message
-        }
-        table.insert(commits, commit)
-      end
-    end
-
-    return commits
-  end)
+    return parse_log(output)
+  end),
+  parse_log = parse_log
 }

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -7,7 +7,7 @@ return {
     options = vim.split(options, ' ')
     table.insert(options, 1, '--oneline')
 
-    local output = a.wait(cli.exec("log",  options))
+    local output = a.wait(cli.log.oneline.args(unpack(options)).call())
     output = vim.split(output, '\n')
     local output_len = #output
     local commits = {}

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -38,16 +38,16 @@ local status = {
       unmerged_changes = {},
       staged_changes = {},
       stashes = nil,
-      unpulled = unpulled ~= "" and util.map(vim.split(unpulled, '\n'), function(x) return { name = x } end) or {},
-      unmerged = unmerged ~= "" and util.map(vim.split(unmerged, '\n'), function(x) return { name = x } end) or {},
+      unpulled = util.map(util.split(unpulled, '\n'), function(x) return { name = x } end),
+      unmerged = util.map(util.split(unmerged, '\n'), function(x) return { name = x } end),
       head = {
-        message = vim.split(head, '\n')[1],
+        message = util.split(head, '\n')[1],
         branch = ""
       },
       upstream = nil
     }
 
-    result.stashes = git.stash.parse(vim.split(stash, '\n'))
+    result.stashes = git.stash.parse(util.split(stash, '\n'))
 
     local function insert_change(list, marker, entry)
       local orig, new = entry:match('^(.-) -> (.*)')
@@ -72,7 +72,7 @@ local status = {
       })
     end
 
-    for _, line in pairs(vim.split(status, '\n')) do
+    for _, line in pairs(util.split(status, '\n')) do
       local marker, details = line:match('(..) (.*)')
 
       if marker == "##" then

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -94,6 +94,11 @@ local function str_count(str, target)
   return count
 end
 
+local function split(str, sep)
+  if str == "" then return {} end
+  return vim.split(str, sep)
+end
+
 return {
   inspect = inspect,
   time = time,
@@ -106,5 +111,6 @@ return {
   create_fold = create_fold,
   get_keymaps = get_keymaps,
   print_tbl = print_tbl,
+  split = split
 }
 

--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -156,7 +156,19 @@ local function create()
         {
           key = "w",
           description = "Reword",
-          callback = function() end
+          callback = function()
+            a.dispatch(function ()
+              local msg = a.wait(cli.log.max_count(1).pretty('%B').call())
+              msg = vim.split(msg, '\n')
+
+              a.wait(prompt_commit_message(msg))
+              local _, code = a.wait(cli.commit.commit_message_file(COMMIT_FILE).amend.only.call())
+              if code == 0 then
+                a.wait(uv.fs_unlink(COMMIT_FILE))
+                __NeogitStatusRefresh(true)
+              end
+            end)
+          end
         },
         {
           key = "a",

--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -94,6 +94,12 @@ local function create()
         enabled = false
       },
       {
+        key = "S",
+        description = "Do not sign this commit",
+        cli = "no-gpg-sign",
+        enabled = false
+      },
+      {
         key = "R",
         description = "Claim authorship and reset author date",
         cli = "reset-author",

--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -136,7 +136,14 @@ local function create()
         {
           key = "e",
           description = "Extend",
-          callback = function() end
+          callback = function(popup)
+            a.dispatch(function ()
+              local _, code = a.wait(cli.commit.no_edit.amend.call())
+              if code == 0 then
+                __NeogitStatusRefresh(true)
+              end
+            end)
+          end
         },
         {
           key = "w",

--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -42,7 +42,7 @@ local prompt_commit_message = a.sync(function (msg)
   table.insert(output, "# Please enter the commit message for your changes. Lines starting")
   table.insert(output, "# with '#' will be ignored, and an empty message aborts the commit.")
 
-  local status_output = a.wait(cli.exec('status'))
+  local status_output = a.wait(cli.status.call())
   status_output = vim.split(status_output, '\n')
 
   for _, line in pairs(status_output) do
@@ -124,8 +124,7 @@ local function create()
           callback = function(popup)
             a.dispatch(function ()
               a.wait(prompt_commit_message(nil))
-              local args = vim.list_extend({"-F", ".git/COMMIT_EDITMSG"}, popup.get_arguments())
-              local _, code = a.wait(cli.exec("commit", args))
+              local _, code = a.wait(cli.commit.commit_message_file('.git/COMMIT_EDITMSG').args(unpack(popup.get_arguments())).call())
               if code == 0 then
                 __NeogitStatusRefresh(true)
               end
@@ -149,11 +148,11 @@ local function create()
           description = "Amend",
           callback = function(popup)
             a.dispatch(function ()
-              local msg = a.wait(cli.exec("log", {"-1", "--pretty=%B"}))
+              local msg = a.wait(cli.log.max_count(1).pretty('%B').call())
               msg = vim.split(msg, '\n')
 
               a.wait(prompt_commit_message(msg))
-              local _, code = a.wait(cli.exec("commit", {"-F", ".git/COMMIT_EDITMSG", "--amend"}))
+              local _, code = a.wait(cli.commit.commit_message_file('.git/COMMIT_EDITMSG').amend.call())
               if code == 0 then
                 __NeogitStatusRefresh(true)
               end

--- a/lua/neogit/popups/pull.lua
+++ b/lua/neogit/popups/pull.lua
@@ -3,6 +3,17 @@ local notif = require("neogit.lib.notification")
 local git = require("neogit.lib.git")
 local a = require('neogit.async')
 
+local function pull_upstream(popup)
+  a.dispatch(function ()
+    local _, code = a.wait(git.cli.pull.no_commit.args(unpack(popup.get_arguments())).call())
+    if code == 0 then
+      a.wait_for_textlock()
+      notif.create "Pulled from upstream"
+      __NeogitStatusRefresh(true)
+    end
+  end)
+end
+
 local function create()
   popup.create(
     "NeogitPullPopup",
@@ -20,21 +31,12 @@ local function create()
         {
           key = "p",
           description = "Pull from pushremote",
-          callback = function() end
+          callback = pull_upstream
         },
         {
           key = "u",
           description = "Pull from upstream",
-          callback = function(popup)
-            a.dispatch(function ()
-              local _, code = a.wait(git.cli.pull.no_commit.args(popup.get_arguments()).call())
-              if code == 0 then
-                a.wait_for_textlock()
-                notif.create "Pulled from upstream"
-                __NeogitStatusRefresh(true)
-              end
-            end)
-          end
+          callback = pull_upstream
         },
         {
           key = "e",

--- a/lua/neogit/popups/pull.lua
+++ b/lua/neogit/popups/pull.lua
@@ -27,7 +27,7 @@ local function create()
           description = "Pull from upstream",
           callback = function()
             a.dispatch(function ()
-              local _, code = a.wait(git.cli.exec("pull", {"--no-commit"}))
+              local _, code = a.wait(git.cli.pull.no_commit.call())
               if code == 0 then
                 a.wait_for_textlock()
                 notif.create "Pulled from upstream"

--- a/lua/neogit/popups/pull.lua
+++ b/lua/neogit/popups/pull.lua
@@ -25,9 +25,9 @@ local function create()
         {
           key = "u",
           description = "Pull from upstream",
-          callback = function()
+          callback = function(popup)
             a.dispatch(function ()
-              local _, code = a.wait(git.cli.pull.no_commit.call())
+              local _, code = a.wait(git.cli.pull.no_commit.args(popup.get_arguments()).call())
               if code == 0 then
                 a.wait_for_textlock()
                 notif.create "Pulled from upstream"

--- a/lua/neogit/popups/push.lua
+++ b/lua/neogit/popups/push.lua
@@ -3,6 +3,17 @@ local notif = require("neogit.lib.notification")
 local git = require("neogit.lib.git")
 local a = require('neogit.async')
 
+local function push_upstream(popup)
+  a.dispatch(function ()
+    local _, code = a.wait(git.cli.push.args(unpack(popup.get_arguments())).call())
+    if code == 0 then
+      a.wait_for_textlock()
+      notif.create "Pushed to pushremote"
+      __NeogitStatusRefresh(true)
+    end
+  end)
+end
+
 local function create()
   popup.create(
     "NeogitPushPopup",
@@ -38,30 +49,12 @@ local function create()
         {
           key = "p",
           description = "Push to pushremote",
-          callback = function(popup)
-            a.dispatch(function ()
-              local _, code = a.wait(git.cli.push.args(unpack(popup.get_arguments())).call())
-              if code == 0 then
-                a.wait_for_textlock()
-                notif.create "Pushed to pushremote"
-                __NeogitStatusRefresh(true)
-              end
-            end)
-          end
+          callback = push_upstream
         },
         {
           key = "u",
           description = "Push to upstream",
-          callback = function(popup)
-            a.dispatch(function ()
-              local _, code = a.wait(git.cli.push.args(unpack(popup.get_arguments())).call())
-              if code == 0 then
-                a.wait_for_textlock()
-                notif.create "Pushed to upstream"
-                __NeogitStatusRefresh(true)
-              end
-            end)
-          end
+          callback = push_upstream
         },
         {
           key = "e",

--- a/lua/neogit/popups/push.lua
+++ b/lua/neogit/popups/push.lua
@@ -40,7 +40,7 @@ local function create()
           description = "Push to pushremote",
           callback = function(popup)
             a.dispatch(function ()
-              local _, code = a.wait(git.cli.exec("push", popup.get_arguments()))
+              local _, code = a.wait(git.cli.push.args(unpack(popup.get_arguments())).call())
               if code == 0 then
                 a.wait_for_textlock()
                 notif.create "Pushed to pushremote"
@@ -54,7 +54,7 @@ local function create()
           description = "Push to upstream",
           callback = function(popup)
             a.dispatch(function ()
-              local _, code = a.wait(git.cli.exec("push", popup.get_arguments()))
+              local _, code = a.wait(git.cli.push.args(unpack(popup.get_arguments())).call())
               if code == 0 then
                 a.wait_for_textlock()
                 notif.create "Pushed to upstream"


### PR DESCRIPTION
Closes #23 

This is from my master branch though, so there's quite a bit more in the MR:
- there's a new way to build and call git commands via a builder pattern. I found the existing way a bit cumbersome and metatables are fun, so here we are :D
- added some of the missing commands for commit and log popups that were easy to add.
- replicated the pull/push commands to both p and u. Since we currently do not have the distinction implemented (and do we even want to?), having one of them do nothing is just confusing.

Regarding #23, I've changed the file we use to store the commit message in. The primary reason is that git manages the `COMMIT_EDITMSG` file itself and that conflicted with the file handling I implemented. We now read the content of the commit message file when opening the dialog and put the existing text into the commit message buffer. That way, if the commit fails, the user gets the last commit message back into the buffer on the next attempt. On a successful commit the file is deleted.