### PR TITLE
Stash popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A **work-in-progress** Magit clone for Neovim that is geared toward the Vim phil
 
 | Plugin Manager                                       | Command                                                                        |
 |------------------------------------------------------|--------------------------------------------------------------------------------|
-| [Packer](https://github.com/wbthomason/packer.nvim)  | `use 'TimUntersberger/neogit'`                                               |
+| [Packer](https://github.com/wbthomason/packer.nvim)  | `use 'TimUntersberger/neogit'`                                                 |
 | [Vim-plug](https://github.com/junegunn/vim-plug)     | `Plug 'TimUntersberger/neogit'`                                                |
 | [NeoBundle](https://github.com/Shougo/neobundle.vim) | `NeoBundle 'TimUntersberger/neogit'`                                           |
 | [Vundle](https://github.com/VundleVim/Vundle.vim)    | `Bundle 'TimUntersberger/neogit'`                                              |
@@ -53,6 +53,7 @@ The create function takes 1 optional argument that can be one of the following v
 | L            | Open log popup                                   |
 | p            | Open pull popup                                  |
 | P            | Open push popup                                  |
+| Z            | Open stash popup                                 |
 | x            | Discard changes (also supports discarding hunks) |
 | \<C-r>       | Refresh Buffer                                   |
 | \<C-C>\<C-C> | Commit (when writing a commit message)           |

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -49,7 +49,13 @@ local configurations = {
       name_only = '--name-only'
     },
   }),
-  stash = config({ }),
+  stash = config({
+    flags = {
+      apply = 'apply',
+      drop = 'drop',
+      index = '--index'
+    }
+  }),
   reset = config({
     flags = {
       hard = '--hard',

--- a/lua/neogit/lib/git/stash.lua
+++ b/lua/neogit/lib/git/stash.lua
@@ -1,3 +1,6 @@
+local cli = require('neogit.lib.git.cli')
+local a = require('neogit.async')
+
 local function parse(output)
   local result = {}
   for _, line in ipairs(output) do
@@ -7,6 +10,103 @@ local function parse(output)
   return result
 end
 
+local function trim_null_terminator(str)
+  return string.gsub(str, "^(.-)%z*$", "%1")
+end
+
+local stash = a.sync(function (include)
+  if not include then return end
+
+  local index = a.wait(
+    cli['commit-tree']
+      .no_gpg_sign
+      .message('test')
+      .parent('HEAD')
+      .tree(a.wait(cli['write-tree'].call()))
+      .call())
+
+  a.wait(
+    cli['read-tree']
+      .merge
+      .index_output('.git/NEOGIT_TMP_INDEX')
+      .args(index)
+      .call())
+
+  print(vim.inspect(include))
+  if include.worktree then
+    local files = a.wait(
+      cli.diff
+        .name_only
+        .null_terminated
+        .args('HEAD')
+        .env({
+          GIT_INDEX_FILE = '.git/NEOGIT_TMP_INDEX'
+        })
+        .call())
+    files = vim.split(trim_null_terminator(files), '\0')
+
+    a.wait(
+      cli['update-index']
+        .add
+        .remove
+        .files(unpack(files))
+        .env({
+          GIT_INDEX_FILE = '.git/NEOGIT_TMP_INDEX'
+        })
+        .call())
+  end
+
+  local tree = a.wait(
+    cli['commit-tree']
+      .no_gpg_sign
+      .message('teststash')
+      .parents('HEAD', index)
+      .tree(a.wait(cli['write-tree'].call()))
+      .env({
+        GIT_INDEX_FILE = '.git/NEOGIT_TMP_INDEX'
+      })
+      .call())
+
+  print(index, tree)
+  a.wait(
+    cli['update-ref']
+      .message('stashentry')
+      .create_reflog
+      .args('refs/stash', tree)
+      .call())
+
+  if include.worktree and include.index then
+    --a.wait(
+      --cli.reset
+        --.hard
+        --.commit('HEAD')
+        --.call())
+  elseif include.index then
+    local diff = a.wait(
+      cli.diff
+        .cached
+        .call()) .. '\n'
+
+    a.wait(
+      cli.apply
+        .reverse
+        .cached
+        .input(diff)
+        .call())
+    a.wait(
+      cli.apply
+        .reverse
+        .input(diff)
+        .call())
+  end
+end)
+
 return {
-  parse = parse
+  parse = parse,
+  stash_all = function ()
+    return stash({ worktree = true, index = true })
+  end,
+  stash_index = function ()
+    return stash({ worktree = false, index = true })
+  end
 }

--- a/lua/neogit/lib/popup/lib.lua
+++ b/lua/neogit/lib/popup/lib.lua
@@ -193,7 +193,7 @@ local function toggle(buf_handle)
 end
 
 
-local function create_popup(id, switches, options, actions)
+local function create_popup(id, switches, options, actions, env)
   local function collect_arguments()
     local flags = {}
     for _, switch in pairs(switches) do
@@ -214,6 +214,7 @@ local function create_popup(id, switches, options, actions)
     switches = switches,
     options = options,
     actions = actions,
+    env = env,
     to_cli = function()
       local flags = collect_arguments()
       return table.concat(flags, " ")

--- a/lua/neogit/popups/stash.lua
+++ b/lua/neogit/popups/stash.lua
@@ -40,11 +40,57 @@ local configuration = {
           end)
         end
       },
+    },
+    {
+      {
+        key = "p",
+        description = "pop",
+        callback = function (popup)
+          local line = vim.fn.getbufline(popup.env.pos[1], popup.env.pos[2])
+          local stash_name = line[1]:match('^(stash@{%d+})')
+          if stash_name then
+            a.dispatch(function ()
+              a.wait(stash.pop(stash_name))
+              __NeogitStatusRefresh(true)
+            end)
+          end
+        end
+      },
+      {
+        key = "a",
+        description = "apply",
+        callback = function (popup)
+          local line = vim.fn.getbufline(popup.env.pos[1], popup.env.pos[2])
+          local stash_name = line[1]:match('^(stash@{%d+})')
+          if stash_name then
+            a.dispatch(function ()
+              a.wait(stash.apply(stash_name))
+              __NeogitStatusRefresh(true)
+            end)
+          end
+        end
+      },
+      {
+        key = "d",
+        description = "drop",
+        callback = function (popup)
+          local line = vim.fn.getbufline(popup.env.pos[1], popup.env.pos[2])
+          local stash_name = line[1]:match('^(stash@{%d+})')
+          if stash_name then
+            a.dispatch(function ()
+              a.wait(stash.drop(stash_name))
+              __NeogitStatusRefresh(true)
+            end)
+          end
+        end
+      }
     }
   }
 }
-local function create()
-  popup.create("NeogitStashPopup", unpack(configuration))
+local function create(pos)
+  popup.create("NeogitStashPopup", configuration[1], configuration[2], configuration[3], {
+    pos = pos
+  })
 end
 
 return {

--- a/lua/neogit/popups/stash.lua
+++ b/lua/neogit/popups/stash.lua
@@ -1,0 +1,52 @@
+local a = require('neogit.async')
+local popup = require('neogit.lib.popup')
+local stash = require('neogit.lib.git.stash')
+
+local configuration = {
+  {
+    --{
+      --key = "a",
+      --description = "",
+      --cli = "all",
+      --enabled = false
+    --},
+    --{
+      --key = "u",
+      --description = "",
+      --cli = "include-untracked",
+      --enabled = false
+    --}
+  },
+  {},
+  {
+    {
+      {
+        key = "z",
+        description = "both",
+        callback = function ()
+          a.dispatch(function ()
+            a.wait(stash.stash_all())
+            __NeogitStatusRefresh(true)
+          end)
+        end
+      },
+      {
+        key = "i",
+        description = "index",
+        callback = function ()
+          a.dispatch(function ()
+            a.wait(stash.stash_index())
+            __NeogitStatusRefresh(true)
+          end)
+        end
+      },
+    }
+  }
+}
+local function create()
+  popup.create("NeogitStashPopup", unpack(configuration))
+end
+
+return {
+  create = create
+}

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -22,12 +22,13 @@ local function spawn(options, cb)
 
   if options.cwd then params.cwd = options.cwd end
   if options.args then params.args = options.args end
-  if options.env then
+  if options.env and #options.env > 0 then
     params.env = {}
     -- setting 'env' completely overrides the parent environment, so we need to
     -- append all variables that are necessary for git to work in addition to
     -- all variables from passed object.
     table.insert(params.env, string.format('%s=%s', 'HOME', os.getenv('HOME')))
+    table.insert(params.env, string.format('%s=%s', 'GNUPGHOME', os.getenv('GNUPGHOME')))
     for k, v in pairs(options.env) do
       table.insert(params.env, string.format('%s=%s', k, v))
     end

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -22,6 +22,16 @@ local function spawn(options, cb)
 
   if options.cwd then params.cwd = options.cwd end
   if options.args then params.args = options.args end
+  if options.env then
+    params.env = {}
+    -- setting 'env' completely overrides the parent environment, so we need to
+    -- append all variables that are necessary for git to work in addition to
+    -- all variables from passed object.
+    table.insert(params.env, string.format('%s=%s', 'HOME', os.getenv('HOME')))
+    for k, v in pairs(options.env) do
+      table.insert(params.env, string.format('%s=%s', k, v))
+    end
+  end
 
   local handle, err
   handle, err = vim.loop.spawn(options.cmd, params, function (code, _)
@@ -32,7 +42,7 @@ local function spawn(options, cb)
     process_closed = true
     raise_if_fully_closed()
   end)
-  --print('started process', vim.inspect(options), '->', handle, err, '@'..(params.cwd or '')..'@')
+  --print('started process', vim.inspect(params), '->', handle, err, '@'..(params.cwd or '')..'@')
   if not handle then
     stdout:close()
     stderr:close()

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -780,7 +780,9 @@ local function create(kind)
       mappings["L"] = require("neogit.popups.log").create
       mappings["P"] = require("neogit.popups.push").create
       mappings["p"] = require("neogit.popups.pull").create
-      mappings["Z"] = require('neogit.popups.stash').create
+      mappings["Z"] = function ()
+        require('neogit.popups.stash').create(vim.fn.getpos('.'))
+      end
       mappings["x"] = { "nv", function () a.run(discard) end, true }
 
       __NeogitStatusRefresh(true)

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -780,6 +780,7 @@ local function create(kind)
       mappings["L"] = require("neogit.popups.log").create
       mappings["P"] = require("neogit.popups.push").create
       mappings["p"] = require("neogit.popups.pull").create
+      mappings["Z"] = require('neogit.popups.stash').create
       mappings["x"] = { "nv", function () a.run(discard) end, true }
 
       __NeogitStatusRefresh(true)


### PR DESCRIPTION
Stash control. This PR implements stashing everything or just the index, as well as popping, applying or dropping a highlighted stash.

Things to note:
- I chose `Z` for the popup, since `z` is used for folds in vim. Any other key would make just as much sense I guess, I'm just not very creative :sweat_smile: 
- The logic for staging the index only is lifted straight from magit. It *should* support also stashing the worktree, however I had no success with that, so I fell back to just using `git stash` for that. Executing the git commands manually though gives the correct result, so I'm not even sure what's the problem. Any hint would be much appreciated, since this issue is also what prevents me from implementing the `--untracked` flag.
- Trying to apply (or drop/pop) a stash while not highlighting one with the cursor currently just silently does nothing. We could in this case, like magit does, prompt for a stash to apply the operation to, but I didn't want to dabble with user input just yet. I need to look into that for branch control anyway though, so I'll get back to that later.
- No stash message can be set for the same reason.