### PR TITLE
chore: move notification hl to syntax-file

### DIFF
--- a/colors/neogit.vim
+++ b/colors/neogit.vim
@@ -1,3 +1,0 @@
-hi NeogitNotificationInfo guifg=#80ff95
-hi NeogitNotificationWarning guifg=#fff454
-hi NeogitNotificationError guifg=#c44323

--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -24,9 +24,6 @@ local neogit = {
     end
   end,
   setup = function(opts)
-    vim.cmd("hi NeogitNotificationInfo guifg=#80ff95")
-    vim.cmd("hi NeogitNotificationWarning guifg=#fff454")
-    vim.cmd("hi NeogitNotificationError guifg=#c44323")
     if opts ~= nil then
       config.values = vim.tbl_deep_extend("force", config.values, opts)
     end

--- a/lua/neogit/lib/notification.lua
+++ b/lua/neogit/lib/notification.lua
@@ -3,10 +3,6 @@ local message_history = {}
 local notifications = {}
 local notification_count = 0
 
-vim.api.nvim_command("hi NeogitNotificationInfo guifg=#80ff95")
-vim.api.nvim_command("hi NeogitNotificationWarning guifg=#fff454")
-vim.api.nvim_command("hi NeogitNotificationError guifg=#c44323")
-
 local function create(message, options)
   notification_count = notification_count + 1
 
@@ -30,6 +26,9 @@ local function create(message, options)
   local col = vim.api.nvim_get_option("columns") - 3
 
   local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_call(buf, function() 
+    vim.bo.filetype = "NeogitNotification"
+  end)
 
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, message)
 
@@ -44,6 +43,9 @@ local function create(message, options)
   })
 
   local border_buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_call(border_buf, function() 
+    vim.bo.filetype = "NeogitNotification"
+  end)
   local border_buf_lines = {}
   width = width + 2
 
@@ -81,7 +83,7 @@ local function create(message, options)
   local timer
   local notification = {
     window = window,
-    buffer = buffer,
+    buffer = buf,
     height = height,
     width = width,
     row = row,

--- a/syntax/NeogitNotification.vim
+++ b/syntax/NeogitNotification.vim
@@ -1,0 +1,3 @@
+hi def NeogitNotificationInfo guifg=#80ff95"
+hi def NeogitNotificationWarning guifg=#fff454"
+hi def NeogitNotificationError guifg=#c44323"


### PR DESCRIPTION
Closes #79 

Doing this one as a PR because I'm not entirely sure this is the right way to do this either. The highlights could just as well go into a `ftplugin`-file or just into our `neogit.vim`. I'm confused :sweat_smile: 