### PR TITLE
Added highlight for the 'unchanged' lines diffs

### DIFF
--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -17,11 +17,6 @@ local hunk_header_matcher = vim.regex('^@@.*@@')
 local diff_add_matcher = vim.regex('^+')
 local diff_delete_matcher = vim.regex('^-')
 
-local function line_is_hunk(line)
-  -- This returns a false positive on untracked file entries
-  return not vim.fn.matchlist(line, "^\\(Modified\\|New file\\|Deleted\\|Conflict\\) .*")[1]
-end
-
 local function get_section_idx_for_line(linenr)
   for i, l in pairs(locations) do
     if l.first <= linenr and linenr <= l.last then
@@ -43,10 +38,6 @@ local function get_section_item_idx_for_line(linenr)
   local section_idx = get_section_idx_for_line(linenr)
   local section = locations[section_idx]
 
-  if section == nil then
-    return nil, nil
-  end
-
   for i, item in pairs(status[section.name]) do
     if item.first <= linenr and linenr <= item.last then
       return section_idx, i
@@ -60,10 +51,6 @@ local function get_section_item_for_line(linenr)
   local section_idx, item_idx = get_section_item_idx_for_line(linenr)
   local section = locations[section_idx]
 
-  if section == nil then
-    return nil, nil
-  end
-
   return section, status[section.name][item_idx]
 end
 
@@ -71,47 +58,8 @@ local function get_current_section_item()
   return get_section_item_for_line(vim.fn.line("."))
 end
 
-local function toggle_sign_at_line(line)
-  local sign_info = status_buffer:get_sign_at_line(line, "fold_markers")
-  local sign = sign_info.signs[1]
-
-  if sign ~= nil then
-    local parts = vim.split(sign.name, ":")
-    local new_name = (parts[1] == "NeogitOpen" and "NeogitClosed" or "NeogitOpen") .. ":" .. parts[2]
-    status_buffer:place_sign(line, new_name, 'fold_markers')
-  end
-end
-
 local function toggle()
   vim.cmd("silent! normal za")
-
-  if not config.values.disable_signs then
-    local section, item = get_current_section_item()
-
-    if section == nil then
-      return
-    end
-
-    local line = item ~= nil and item.first or section.first
-
-    local on_hunk = item ~= nil and line_is_hunk(vim.fn.getline('.'))
-
-
-    if on_hunk then
-      local ignored_sections = { "untracked_files", "stashes", "unpulled", "unmerged" }
-
-      for _, val in pairs(ignored_sections) do
-        if val == section.name then
-          return
-        end
-      end
-
-      local hunk = get_current_hunk_of_item(item)
-      line = item.first + hunk.first
-    end
-
-    toggle_sign_at_line(line)
-  end
 end
 
 local function change_to_str(change)
@@ -206,6 +154,7 @@ local function display_status()
               status_buffer:place_sign(line_idx, 'NeogitDiffAdd', 'hl')
             elseif diff_delete_matcher:match_str(diff_line) then
               status_buffer:place_sign(line_idx, 'NeogitDiffDelete', 'hl')
+            else status_buffer:place_sign(line_idx, 'NeogitDiffContext', 'hl')
             end
           end
           item.diff_open = true
@@ -287,22 +236,13 @@ local function display_status()
           for _,h in ipairs(i.diff_content.hunks) do
             status_buffer:create_fold(i.first + h.first, i.first + h.last)
             status_buffer:open_fold(i.first + h.first)
-            if not config.values.disable_signs then
-              status_buffer:place_sign(i.first + h.first, "NeogitOpen:hunk", "fold_markers")
-            end
           end
         end
         status_buffer:create_fold(i.first, i.last)
-        if not config.values.disable_signs and l.name ~= "untracked_files" then
-          status_buffer:place_sign(i.first, "NeogitClosed:item", "fold_markers")
-        end
       end
     end
     status_buffer:create_fold(l.first, l.last)
     status_buffer:open_fold(l.first)
-    if not config.values.disable_signs then
-      status_buffer:place_sign(l.first, "NeogitOpen:section", "fold_markers")
-    end
   end
 
   vim.fn.winrestview(old_view)
@@ -640,6 +580,11 @@ local unstage_selection = a.sync(function()
   a.wait(cli.apply.reverse.cached.with_patch(patch).call())
 end)
 
+local function line_is_hunk(line)
+  -- This returns a false positive on untracked file entries
+  return not vim.fn.matchlist(line, "^\\(Modified\\|New file\\|Deleted\\|Conflict\\) .*")[1]
+end
+
 local stage = a.sync(function()
   current_operation = "stage"
   local section, item = get_current_section_item()
@@ -653,6 +598,7 @@ local stage = a.sync(function()
   if mode.mode == "V" then
     a.wait(stage_selection())
   else
+
     local on_hunk = line_is_hunk(vim.fn.getline('.'))
 
     if on_hunk and section.name ~= "untracked_files" then
@@ -820,22 +766,6 @@ local cmd_func_map = {
   ["CommandHistory"] = function()
     GitCommandHistory:new():show()
   end,
-  ["GoToFile"] = function()
-    local section, item = get_current_section_item()
-
-    if item ~= nil then
-      if section.name ~= "unstaged_changes" and section.name ~= "staged_changes" and section.name ~= "untracked_files" then
-        return
-      end
-
-      local path = item.name
-
-      notif.delete_all()
-      status_buffer:close()
-
-      vim.cmd("e " .. path)
-    end
-  end,
   ["RefreshBuffer"] = function() __NeogitStatusRefresh(true) end,
   ["HelpPopup"] = function ()
     local pos = vim.fn.getpos('.')
@@ -884,8 +814,6 @@ end
 
 local highlight_group = vim.api.nvim_create_namespace("section-highlight")
 local function update_highlight()
-  if config.values.disable_context_highlighting then return end
-
   vim.api.nvim_buf_clear_namespace(0, highlight_group, 0, -1)
   status_buffer:clear_sign_group('ctx')
 

--- a/syntax/NeogitStatus.vim
+++ b/syntax/NeogitStatus.vim
@@ -40,14 +40,16 @@ hi def link NeogitUnpulledFrom Function
 
 hi def link NeogitStash Comment
 
-hi def NeogitDiffAddHighlight guibg=#404040 guifg=#859900
-hi def NeogitDiffDeleteHighlight guibg=#404040 guifg=#dc322f
-hi def NeogitDiffContextHighlight guibg=#333333 guifg=#b2b2b2
+hi def NeogitDiffAddHighlight guibg=#404040
+hi def NeogitDiffDeleteHighlight guibg=#404040
+hi def NeogitDiffContext guibg=#404040
+hi def NeogitDiffContextHighlight ctermbg=4 guibg=#333333
 hi def NeogitHunkHeader guifg=#cccccc guibg=#404040
 hi def NeogitHunkHeaderHighlight guifg=#cccccc guibg=#4d4d4d
 
 hi def NeogitFold guifg=None guibg=None
 
+sign define NeogitDiffContext linehl=NeogitDiffContext
 sign define NeogitDiffContextHighlight linehl=NeogitDiffContextHighlight
 sign define NeogitHunkHeader linehl=NeogitHunkHeader
 sign define NeogitHunkHeaderHighlight linehl=NeogitHunkHeaderHighlight


### PR DESCRIPTION
Altered `lua/neogit/status.lua` and `/syntax/NeogitStatus.vim` so the unaltered lines in diffs have a highlight called `NeogitDiffDelete`