### PR TITLE
Fix issue when cwd is not git root directory

### DIFF
--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -6,11 +6,26 @@ local a = require('neogit.async')
 local uv = require('neogit.async.uv')
 local split = require('neogit.lib.util').split
 
-local COMMIT_FILE = '.git/NEOGIT_COMMIT_EDITMSG'
+local find_root = function()
+  local base_pwd = vim.fn.getcwd()
+  local target = string.byte("/")
+  for idx = #base_pwd, 1, -1 do
+    if base_pwd:byte(idx) == target then
+      local gitpath = base_pwd:sub(1, idx) .. ".git"
+      if vim.fn.isdirectory(gitpath) > 0 then
+        return gitpath
+      end
+    end
+  end
+  return ".git"
+end
+
+local commit_file = function() return find_root() .. '/NEOGIT_COMMIT_EDITMSG' end
 
 local get_commit_message = a.wrap(function (content, cb)
+
   Buffer.create {
-    name = COMMIT_FILE,
+    name = commit_file(),
     filetype = "gitcommit",
     buftype = "",
     modifiable = true,
@@ -82,6 +97,7 @@ local prompt_commit_message = a.sync(function (msg)
 end)
 
 local function create()
+  local COMMIT_FILE = commit_file()
   popup.create(
     "NeogitCommitPopup",
     {


### PR DESCRIPTION
Address issue of assuming {,t,l}cd is root folder.

Fix #90
Fix #91

---

The function introduced in neogit/popups/commit.lua can be moved elsewhere if needed, but seemed to make sense to keep it local for the time being.