### PR TITLE
Add option to disable commit confirmation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ local neogit = require("neogit")
 neogit.setup {
   disable_signs = false,
   disable_context_highlighting = false,
+  disable_commit_confirmation = false,
   -- customize displayed signs
   signs = {
     -- { CLOSED, OPENED }

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ You can override them to fit your colorscheme by creating a `syntax/NeogitStatus
 
 Set `disable_context_highlighting = true` in your call to [`setup`](#configuration) to disable context highlighting altogether.
 
+## Disabling Commit Confirmation
+
+Set `disable_commit_confirmation = true` in your call to [`setup`](#configuration) to disable the "Are you sure you want to commit?" prompt after saving the commit message buffer.
+
 ## Events
 
 Neogit emits a `NeogitStatusRefreshed` event whenever the status gets reloaded.

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -3,6 +3,7 @@ local M = {}
 M.values = {
   disable_context_highlighting = false,
   disable_signs = false,
+  disable_commit_confirmation = false,
   signs = {
     hunk = { "", "" },
     item = { ">", "v" },

--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -3,6 +3,7 @@ local status = require 'neogit.status'
 local cli = require("neogit.lib.git.cli")
 local input = require("neogit.lib.input")
 local Buffer = require("neogit.lib.buffer")
+local config = require("neogit.config")
 local a = require 'plenary.async_lib'
 local async, await, scheduler, void, wrap, uv = a.async, a.await, a.scheduler, a.void, a.wrap, a.uv
 local split = require('neogit.lib.util').split
@@ -31,7 +32,8 @@ local get_commit_message = wrap(function (content, cb)
 
       _G.__NEOGIT_COMMIT_BUFFER_CB_UNLOAD = function()
         if written then
-          if input.get_confirmation("Are you sure you want to commit?") then
+          if config.values.disable_commit_confirmation or
+              input.get_confirmation("Are you sure you want to commit?") then
             vim.cmd [[
               silent g/^#/d
               silent w!


### PR DESCRIPTION
Open for discussion: I'm not sure whether this is something that would be useful to other people (and hence belongs in this plugin) or not. I personally find it a bit burdensome (and takes me out of my flow) since I'm used to typing my message, hitting "ZZ" and then moving on.

This is also my first time writing Lua so if there's a better way to format this conditional, please let me know.