### PR TITLE
fix(diffview): Handle files without stats correctly.

### DIFF
--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -60,10 +60,10 @@ function M.open(selected_file_name)
         local file = {
           path = item.name,
           status = item.mode,
-          stats = {
+          stats = (item.diff and item.diff.stats) and {
             additions = item.diff.stats.additions or 0,
             deletions = item.diff.stats.deletions or 0
-          },
+          } or nil,
           left_null = vim.tbl_contains({ "A", "?" }, item.mode),
           right_null = false,
           selected = item.name == selected_file_name


### PR DESCRIPTION
Neogit's file struct items don't always have stats attached to them (for instance for deleted files), in which case an error is thrown when trying to open diffview.