### PR TITLE
chore: fix some tests and make test harness more robust to individual failures

### DIFF
--- a/lua/neogit/popups.lua
+++ b/lua/neogit/popups.lua
@@ -5,4 +5,6 @@ return {
   pull = require("neogit.popups.pull"),
   stash = require("neogit.popups.stash"),
   help = require("neogit.popups.help"),
+  diff = require("neogit.popups.diff"),
+  branch = require("neogit.popups.branch"),
 }

--- a/tests/git_harness.lua
+++ b/tests/git_harness.lua
@@ -31,9 +31,15 @@ function M.in_prepared_repo(cb)
   return function ()
     local dir = 'neogit_test_'..random_string(5)
     prepare_repository(dir)
-    vim.cmd('Neogit')
+    local _, err = pcall(function()
+      vim.cmd('Neogit')
+    end)
+    if err ~= nil then
+      cleanup_repository(dir)
+      error(err)
+    end
     a.util.block_on(status.reset())
-    local _, err = pcall(cb)
+    _, err = pcall(cb)
     cleanup_repository(dir)
     if err ~= nil then
       error(err)


### PR DESCRIPTION
I noticed that the tests are failing both locally and in GitHub actions. They're "succeeding" because of the [`continue-on-error`](https://github.com/TimUntersberger/neogit/blob/master/.github/workflows/test.yml#L22) block in test.yml

The first issue (that this PR fixes) is that if calling `Neogit` in the `git_harness` setup fails, then the working directory wasn't getting reset. So I changed that to a `pcall()` and called the cleanup if it failed.

You can see this currently manifests as all tests requiring the git repo harness **after** a failing test will fail with a "can't find directory" error:

```
Fail	||	status buffer staging files - s can stage a subsequent hunk under the cursor of a tracked file	
            ./tests/git_harness.lua:21: Vim(cd):E344: Can't find directory "/tmp/neogit_test_koufu" in cdpath
            
            stack traceback:
            	./tests/git_harness.lua:21: in function 'prepare_repository'
            	./tests/git_harness.lua:33: in function <./tests/git_harness.lua
```

This is because the `cp tests/.repo` command (that creates the temp directory) is failing, because the working directory wasn't being reset.

The second issue I found is that some requires() were failing -- `neogit.popups.diff` and `neogit.popups.branch` were not present in `popups.lua`. This seems to only be an issue in tests, but it seems harmless to add these.

Example of the current master build failing on this error: https://github.com/TimUntersberger/neogit/runs/2869021175#step:4:39

This doesn't entirely fix the tests, however. I spent some time trying to debug why `status_buf_spec.lua` was failing. It seems like maybe (?) the `<tab>` isn't getting fed properly to expand the staged file. I'm not too familiar with the neovim APIs so I didn't spend too much time on it.

If you have any thoughts on why this may be happening, I'm happy to continue investigating, and then we can turn off the `continue-on-error` flag, assuming you want test failures to show up as Red on GitHub actions.