### PR TITLE
feat: add support for pushing to ssh:// remotes

### DIFF
--- a/lua/neogit/popups/push.lua
+++ b/lua/neogit/popups/push.lua
@@ -54,7 +54,9 @@ local get_remote_url = async(function(remote)
         end
       end
     elseif vim.startswith(raw_url, "ssh") then
-      error("TODO: ssh protocol")
+      local url = {}
+      url.protocol, url.username, url.rest = raw_url:match("(.*)://(.*)@(.*)")
+      return url
     elseif vim.startswith(raw_url, "git@") then
       local raw_url = raw_url:gsub("www%.", "")
       local url = { protocol = "git_ssh" }
@@ -85,7 +87,7 @@ local construct_url_str = function(url)
 
     return string.format("%s://%s:%s@%s", url.protocol, url.username, url.password, url.rest)
   elseif url.protocol == "ssh" then
-    error("TODO: ssh protocol")
+    return string.format("%s://%s@%s", url.protocol, url.username, url.rest)
   elseif url.protocol == "git_ssh" then
     return string.format("%s@%s", url.username, url.rest)
   else


### PR DESCRIPTION
I'm not totally clear on why we need to parse out the username/rest (rather than just using the raw remote URL for the push operation), but this seems to work and follows the existing pattern.

I've tested this on my personal git server, which has a remote of the form `ssh://git@<host>:<port>/<repo>`