### PR TITLE
Use vim.notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ neogit.setup {
   disable_context_highlighting = false,
   disable_commit_confirmation = false,
   auto_refresh = true,
+  disable_builtin_notifications = false,
   commit_popup = {
       kind = "split",
   },

--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -33,7 +33,7 @@ function M.new(commit_id, notify)
     buffer = nil
   }
 
-  if notify then
+  if notification then
     notification:delete()
   end
 

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -4,6 +4,7 @@ M.values = {
   disable_context_highlighting = false,
   disable_signs = false,
   disable_commit_confirmation = false,
+  disable_builtin_notifications = false,
   auto_refresh = true,
   commit_popup = {
       kind = "split",

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -313,11 +313,7 @@ local function handle_new_cmd(job, popup, hidden_text)
 
   if popup and job.code ~= 0 then
     vim.schedule(function ()
-      notif.create({
-        "Git Error (" .. job.code .. ")!",
-        "",
-        "Press $ to see the git command history."
-      }, { type = "error" })
+      notif.create("Git Error (" .. job.code .. "), press $ to see the git command history", vim.log.levels.ERROR)
     end)
   end
 end

--- a/lua/neogit/lib/popup.lua
+++ b/lua/neogit/lib/popup.lua
@@ -210,7 +210,7 @@ function M:show()
       else
         mappings.n[action.key] = function()
           local notif = require 'neogit.lib.notification'
-          notif.create(action.description .. " has not been implemented yet", { type = "warning" })
+          notif.create(action.description .. " has not been implemented yet", vim.log.levels.WARN)
         end
       end
     end

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -55,19 +55,6 @@ local function print_tbl(tbl)
   end
 end
 
-local function tbl_longest_str(tbl)
-  local len = 0
-
-  for _,str in pairs(tbl) do
-    local str_len = #str
-    if str_len > len then
-      len = str_len
-    end
-  end
-
-  return len
-end
-
 local function get_keymaps(mode, startswith)
   local maps = vim.api.nvim_get_keymap(mode)
   if startswith then
@@ -159,7 +146,6 @@ return {
   slice = slice,
   map = map,
   range = range,
-  tbl_longest_str = tbl_longest_str,
   filter = filter,
   str_right_pad = str_right_pad,
   str_count = str_count,

--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -86,10 +86,12 @@ local function do_commit(popup, data, cmd, skip_gen)
     prompt_commit_message(popup:get_arguments(), data, skip_gen)
   end
   a.util.scheduler()
-  local notification = notif.create("Committing...", { delay = 9999 })
+  local notification = notif.create("Committing...", vim.log.levels.INFO, 9999)
   local _, code = cmd.call()
   a.util.scheduler()
-  notification:delete()
+  if notification then
+    notification:delete()
+  end
   notif.create("Successfully committed!")
   if code == 0 then
     a.uv.fs_unlink(commit_file)


### PR DESCRIPTION
I replaced all notifications with `vim.notify`. All messages will be displayed in echo area by default, but users can simply override this function to have nice notifications as they want or use a dedicated plugin, such as https://github.com/rcarriga/nvim-notify

In theory you can also use `vim.log.levels.TRACE` for debugging.

Closes #193