### PR TITLE
Add Insert on commit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ Set `disable_context_highlighting = true` in your call to [`setup`](#configurati
 
 Set `disable_commit_confirmation = true` in your call to [`setup`](#configuration) to disable the "Are you sure you want to commit?" prompt after saving the commit message buffer.
 
+## Disabling Insert On Commit
+
+Set `disable_insert_on_commit = true` in your call to [`setup`](#configuration) to disable automatically changing to insert mode when opening the commit message buffer. (Disabled is the default)
+
 ## Events
 
 Neogit emits a `NeogitStatusRefreshed` event whenever the status gets reloaded.

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -5,6 +5,7 @@ M.values = {
   disable_signs = false,
   disable_commit_confirmation = false,
   disable_builtin_notifications = false,
+  disable_insert_on_commit = true,
   auto_refresh = true,
   commit_popup = {
       kind = "split",

--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -51,6 +51,9 @@ local get_commit_message = a.wrap(function (content, cb)
     },
     initialize = function(buffer)
       buffer:set_lines(0, -1, false, content)
+      if not config.values.disable_insert_on_commit then
+        vim.cmd(":startinsert")
+      end
     end
   }
 end, 2)


### PR DESCRIPTION
Hey! 

First off, love the plugin, appreciate all the work you've done.

One thing I missed from Magit was, once the commit popup appeared, you could begin typing immediately instead of switching into insert mode and then typing.

I added a configuration option to allow for that behavior, while keeping the default. 

The naming is kind of awkward since I was trying to stick with the other vars you had but let me know if you'd like me to switch to something like "enable_insert_on_commit" instead of the negative.

Thanks again!