### PR TITLE
fix: Parsing of upstream remote + branch.

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -192,7 +192,8 @@ local configurations = {
       all = '-a',
       delete = '-d',
       remotes = '-r',
-      tracking = '-vv',
+      current = '--show-current',
+      very_verbose = '-vv',
     },
     aliases = {
       name = function (tbl)
@@ -269,7 +270,20 @@ local configurations = {
       cached = '--cached',
       full_name = '--full-name'
     },
-  })
+  }),
+  ['rev-parse'] = config({
+    flags = {
+      revs_only = "--revs-only",
+      no_revs = "--no-revs",
+      flags = "--flags",
+      no_flags = "--no-flags",
+      symbolic = "--symbolic",
+      symbolic_full_name = "--symbolic-full-name",
+    },
+    options = {
+      abbrev_ref = "--abbrev-ref",
+    },
+  }),
 }
 
 local function git_root()


### PR DESCRIPTION
As I mentioned in #239, the current approach makes some false assumptions about valid formatting for remote- and branch names. A regex won't be enough to separate these when they're presented together because there's no unique separator between them. I think the most straight forward approach is to just read the branch's remote from the git config.