### PR TITLE
fix: Account for partial lines in job output.

### DIFF
--- a/lua/neogit/lib/job.lua
+++ b/lua/neogit/lib/job.lua
@@ -50,6 +50,9 @@ function Job:start()
     task = { 'cmd', '/C', task }
   end
 
+  local stdout_line_buffer = ""
+  local stderr_line_buffer = ""
+
   self.channel = vim.fn.jobstart(task, {
     cwd = self.cwd,
     on_exit = function(_, code)
@@ -63,6 +66,8 @@ function Job:start()
       end
     end,
     on_stdout = function(_, data)
+      data[1] = stdout_line_buffer .. data[1]
+
       for i=1,#data-1 do
         local data = data[i]:gsub("\r", "")
         if type(self.on_stdout) == "function" then
@@ -70,8 +75,12 @@ function Job:start()
         end
         table.insert(self.stdout, data)
       end
+
+      stdout_line_buffer = data[#data]
     end,
     on_stderr = function(_, data)
+      data[1] = stderr_line_buffer .. data[1]
+
       for i=1,#data-1 do
         local data = data[i]:gsub("\r", "")
         if type(self.on_stderr) == "function" then
@@ -79,6 +88,8 @@ function Job:start()
         end
         table.insert(self.stderr, data)
       end
+
+      stderr_line_buffer = data[#data]
     end,
   })
 end


### PR DESCRIPTION
The last line in a job channel callback may be a partial line. Until now this has just been ignored. Seemingly, this works fine most of the time, but I had a commit view consistently fail to parse `git-show` output because several characters were dropped from the beginning of a line.

From `:h channel-callback`:

```vimhelp
      {data}	    Raw data (|readfile()|-style list of strings) read from
		    the channel. EOF is a single-item list: `['']`. First and
		    last items may be partial lines! |channel-lines|
```