### PR TITLE
Fix git commit amend appending unnecessary template

### DIFF
--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -149,7 +149,7 @@ function M.create()
       local commit_file = get_commit_file()
       local msg = cli.log.max_count(1).pretty('%B').call()
 
-      do_commit(popup, msg, tostring(cli.commit.commit_message_file(commit_file).amend))
+      do_commit(popup, msg, tostring(cli.commit.commit_message_file(commit_file).amend), true)
     end)
     :new_action_group()
     :action("f", "Fixup")


### PR DESCRIPTION
The issue is when we do `ca`, the pop up git message appends git message template. This contradicts the behavior from `git commit --amend`, which just use the previous git message without appending anything.

