### PR TITLE
get_current_hunk_of_item returns nil if the item is not tracked by git

### DIFF
--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -422,6 +422,9 @@ local function get_hunk_of_item_for_line(item, line)
 end
 
 local function get_current_hunk_of_item(item)
+  if item.hunks == nil then
+    return nil
+  end
   return get_hunk_of_item_for_line(item, vim.fn.line("."))
 end
 


### PR DESCRIPTION
previously get_current_hunk_of_item would fail if the file was not tracked
by git. The reason was that get_current_hunk_of_item calls
get_hunk_of_item_for_line, which loops over ipairs(item.hunks), which
will fail if item.hunks is nil.

An important consequence of this is that going to a specific file in the
status would fail if the file was not tracked by git (for instance, it's
a new file we're adding to the repo now). The code to go to a file is
calling get_current_hunk_of_item to find out which line to go to in the
file.