### PR TITLE
fix: update help popup according to user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ neogit.setup {
   disable_commit_confirmation = false,
   auto_refresh = true,
   disable_builtin_notifications = false,
+  use_magit_keybindings = false,
   commit_popup = {
       kind = "split",
   },
@@ -205,16 +206,6 @@ List of status commands:
 * StashPopup
 * BranchPopup
 
-### Magit-style keybindings
-
-Neogit uses 'p' for pulling instead of 'F'.
-
-Add the following line to your config to use magit-style keybindings.
-
-```lua
-neogit.config.use_magit_keybindings()
-```
-
 ## Notification Highlighting
 
 Neogit defines three highlight groups for the notifications:
@@ -267,6 +258,12 @@ autocmd User NeogitStatusRefreshed echom "Hello World!"
 ```
 
 Further information can be found under `:h autocmd`.
+
+## Magit-style Keybindings
+
+Neogit uses 'p' for pulling instead of 'F'.
+
+Set `use_magit_keybindings = true` in your call to [`setup`](#configuration) to use magit-style keybindings.
 
 ## Todo
 

--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -48,6 +48,9 @@ local neogit = {
     if not config.values.disable_signs then
       signs.setup()
     end
+    if config.values.use_magit_keybindings then
+      config.use_magit_keybindings()
+    end
     hl.setup()
   end
 }

--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -49,7 +49,8 @@ local neogit = {
       signs.setup()
     end
     if config.values.use_magit_keybindings then
-      config.use_magit_keybindings()
+      config.values.mappings.status["F"] = "PullPopup"
+      config.values.mappings.status["p"] = ""
     end
     hl.setup()
   end

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -90,9 +90,4 @@ function M.ensure_integration(name)
   return true
 end
 
-function M.use_magit_keybindings()
-  M.values.mappings.status['F'] = 'PullPopup'
-  M.values.mappings.status['p'] = ''
-end
-
 return M

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -7,6 +7,7 @@ M.values = {
   disable_commit_confirmation = false,
   disable_builtin_notifications = false,
   disable_insert_on_commit = true,
+  use_magit_keybindings = false,
   auto_refresh = true,
   kind = "tab",
   status = {

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -92,7 +92,7 @@ end
 
 function M.use_magit_keybindings()
   M.values.mappings.status['F'] = 'PullPopup'
-  M.values.mappings.status['p'] = 'PushPopup'
+  M.values.mappings.status['p'] = ''
 end
 
 return M

--- a/lua/neogit/popups/help.lua
+++ b/lua/neogit/popups/help.lua
@@ -5,9 +5,10 @@ local GitCommandHistory = require("neogit.buffers.git_command_history")
 local M = {}
 
 function M.create(env)
+  local m = env.use_magit_keybindings
   local p = popup.builder()
     :name("NeogitHelpPopup")
-    :action("p", "Pull", function()
+    :action(m and "F" or "p", "Pull", function()
       require('neogit.popups.pull').create()
     end)
     :action("P", "Push", function()

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -842,7 +842,8 @@ local cmd_func_map = function ()
           return {
             name = line[1]:match('^(stash@{%d+})') 
           }
-        end
+        end,
+        use_magit_keybindings = config.values.use_magit_keybindings
       }
     end,
     ["DiffAtFile"] = function()


### PR DESCRIPTION
Addresses #244 

Changes of this PR:
- using magit keybindings can be done directly through the `setup` function with `use_magit_keybindings = true`
  - `false` by default
- unbind `p` in magit keybindings, used to be "push" but `P` does the same thing and this is more magit-like
- help popup now shows correct keybindings by inspecting `config.values.use_magit_keybindings`
- documentation changes

I welcome any changes/comments to this PR.

P.S. for backward compatibility, I still keep the `config.use_magit_keybindings()` function. I can remove it if you want.