### PR TITLE
fix: short circuit refresh on dirvish

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,19 @@ Neogit uses 'p' for pulling instead of 'F'.
 
 Set `use_magit_keybindings = true` in your call to [`setup`](#configuration) to use magit-style keybindings.
 
+## Refreshing Neogit
+
+If you would like to refresh Neogit manually, you can use `neogit#refresh_manually` in Vimscript or `require('neogit').refresh_manually` in lua. They both require a single file parameter.
+
+This allows you to refresh Neogit on your own custom events
+
+```vim
+augroup DefaultRefreshEvents
+  au!
+  au BufWritePost,BufEnter,FocusGained,ShellCmdPost,VimResume * call <SID>neogit#refresh_manually(expand('<afile>'))
+augroup END
+```
+
 ## Todo
 
 **Note: This file is no longer being updated.**

--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -38,6 +38,7 @@ local neogit = {
   end,
   dispatch_reset = status.dispatch_reset,
   refresh = status.refresh,
+  refresh_manually = status.refresh_manually,
   dispatch_refresh = status.dispatch_refresh,
   refresh_viml_compat = status.refresh_viml_compat,
   close = status.close,

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -395,9 +395,10 @@ local dispatch_refresh = a.void(refresh)
 local refresh_viml_compat = a.void(function (fname)
   if not fname or fname == "" then return end
 
+  if not config.values.auto_refresh then return end
+
   local path = fs.relpath_from_repository(fname)
   if not path then return end
-  if not config.values.auto_refresh then return end
   refresh({ status = true, diffs = { "*:" .. path } })
 end)
 

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -388,19 +388,23 @@ end
 
 local dispatch_refresh = a.void(refresh)
 
---- Compatibility endpoint to refresh data from an autocommand.
---  `fname` should be `<afile>` in this case. This function will take care of
---  resolving the file name to the path relative to the repository root and
---  refresh that file's cache data.
-local refresh_viml_compat = a.void(function (fname)
+local refresh_manually = a.void(function (fname)
   if not fname or fname == "" then return end
-
-  if not config.values.auto_refresh then return end
 
   local path = fs.relpath_from_repository(fname)
   if not path then return end
   refresh({ status = true, diffs = { "*:" .. path } })
 end)
+
+--- Compatibility endpoint to refresh data from an autocommand.
+--  `fname` should be `<afile>` in this case. This function will take care of
+--  resolving the file name to the path relative to the repository root and
+--  refresh that file's cache data.
+local function refresh_viml_compat(fname)
+  if not config.values.auto_refresh then return end
+
+  refresh_manually(fname)
+end
 
 local function current_line_is_hunk()
   local _,_,h = save_cursor_location()
@@ -967,6 +971,7 @@ M.dispatch_reset = dispatch_reset
 M.refresh = refresh
 M.dispatch_refresh = dispatch_refresh
 M.refresh_viml_compat = refresh_viml_compat
+M.refresh_manually = refresh_manually
 M.close = close
 
 function M.enable()

--- a/plugin/neogit.vim
+++ b/plugin/neogit.vim
@@ -7,6 +7,10 @@ if !luaeval("require 'neogit.bootstrap'")
   finish
 endif
 
+function! neogit#refresh_manually(file)
+  call luaeval('(function() require "neogit.status".refresh_manually(_A) end)()', a:file)
+endfunction
+
 function! s:refresh(file)
   if match(bufname(), "^\\(Neogit.*\\|.git/COMMIT_EDITMSG\\)$") == 0
     return


### PR DESCRIPTION
Resolves an issue where, if we're in a large repo, dirvish will refresh Neogit aggressively. For me, this causes memory to go out of control because of `git ls-files` being run on a large repo over and over

