### PR TITLE
remove default kind "tab" in open function

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -29,7 +29,7 @@ local neogit = {
         popup.create()
       end
     else
-      status.create(opts.kind or "tab", opts.cwd)
+      status.create(opts.kind, opts.cwd)
     end
   end,
   reset = status.reset,


### PR DESCRIPTION
The open function still overrides the default kind option from the setup.