### PR TITLE
fix file discard path

### DIFF
--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -701,8 +701,9 @@ local discard = function()
       cli.apply.reverse.with_patch(patch).call()
     end
   elseif section.name == "untracked" then
+    local repo_root = cli.git_root()
     a.util.scheduler()
-    vim.fn.delete(item.name)
+    vim.fn.delete(repo_root .. '/' .. item.name)
   else
 
     local on_hunk = current_line_is_hunk()


### PR DESCRIPTION
the git status file discard code assumed that the vim current folder was set to the git repository root, which is not necessarily the case. This fixes it.