### PR TITLE
fix(#286): add diffview support for commit & stash

### DIFF
--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -857,10 +857,10 @@ local cmd_func_map = function ()
         return
       end
       local dv = require 'neogit.integrations.diffview'
-      local _, item = get_current_section_item()
+      local section, item = get_current_section_item()
 
-      if item then
-        dv.open(item.name)
+      if section and item then
+        dv.open(section.name, item.name)
       end
     end,
     ["DiffPopup"] = require("neogit.popups.diff").create,


### PR DESCRIPTION
**Description :**
As described in issue #286, when you press `d` to open diffview on commit or stash it doesn't work and display an error.

**FIx :**
This PR adds support for opening of diffview for commit and stash.
It compares the section and try to extract the commit id or stash id.

If the cursor is in `recent` or `unmerged` section it extracts the commit id, if the cursor is in `stashes` section it extracts the stash id.

In all other cases, it reverts to the original behavior.