### PR TITLE
Handles non-existent commands.

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -21,9 +21,9 @@ local neogit = {
     opts = opts or {}
     if opts[1] ~= nil then
       local popup_name = opts[1]
-      local popup = require("neogit.popups." .. popup_name)
+      local has_pop, popup = pcall(require, "neogit.popups." .. popup_name)
 
-      if popup == nil then
+      if not has_pop then
         vim.api.nvim_err_writeln("Invalid popup '" .. popup_name .. "'")
       else
         popup.create()


### PR DESCRIPTION
When the user types some command that does not have a popup associated with it, Neogit throws an error. It fixes #278.