### PR TITLE
Fixed diffs when diff.external is set to something that cannot be parsed

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -82,7 +82,8 @@ local configurations = {
       cached = '--cached',
       shortstat = '--shortstat',
       patch = '--patch',
-      name_only = '--name-only'
+      name_only = '--name-only',
+      no_ext_diff = "--no-ext-diff"
     },
   }),
   stash = config({

--- a/lua/neogit/lib/git/diff.lua
+++ b/lua/neogit/lib/git/diff.lua
@@ -131,7 +131,7 @@ local diff = {
   parse = parse_diff,
   parse_stats = parse_diff_stats,
   get_stats = function(name)
-    return parse_diff_stats(cli.diff.shortstat.files(name).call_sync())
+    return parse_diff_stats(cli.diff.no_ext_diff.shortstat.files(name).call_sync())
   end
 }
 
@@ -160,8 +160,8 @@ function diff.register(meta)
     if type(filter) == 'table' then
       filter = ItemFilter.new(Collection.new(filter):map(function (item)
         local section, file = item:match("^([^:]+):(.*)$")
-        if not section then 
-          error('Invalid filter item: '..item, 3) 
+        if not section then
+          error('Invalid filter item: '..item, 3)
         end
 
         return { section = section, file = file }
@@ -171,8 +171,8 @@ function diff.register(meta)
     for _, f in ipairs(repo.unstaged.items) do
       if f.mode ~= 'D' and f.mode ~= 'F' and (not filter or filter:accepts('unstaged', f.name)) then
         table.insert(executions, function ()
-          local raw_diff = cli.diff.files(f.name).call()
-          local raw_stats = cli.diff.shortstat.files(f.name).call()
+          local raw_diff = cli.diff.no_ext_diff.files(f.name).call()
+          local raw_stats = cli.diff.no_ext_diff.shortstat.files(f.name).call()
           f.diff = parse_diff(raw_diff)
           f.diff.stats = parse_diff_stats(raw_stats)
         end)
@@ -182,8 +182,8 @@ function diff.register(meta)
     for _, f in ipairs(repo.staged.items) do
       if f.mode ~= 'D' and f.mode ~= 'F' and (not filter or filter:accepts('staged', f.name)) then
         table.insert(executions, function ()
-          local raw_diff = cli.diff.cached.files(f.name).call()
-          local raw_stats = cli.diff.cached.shortstat.files(f.name).call()
+          local raw_diff = cli.diff.no_ext_diff.cached.files(f.name).call()
+          local raw_stats = cli.diff.no_ext_diff.cached.shortstat.files(f.name).call()
           f.diff = parse_diff(raw_diff)
           f.diff.stats = parse_diff_stats(raw_stats)
         end)

--- a/lua/neogit/lib/git/stash.lua
+++ b/lua/neogit/lib/git/stash.lua
@@ -33,6 +33,7 @@ local function perform_stash(include)
   if include.worktree then
     local files = 
       cli.diff
+        .no_ext_diff
         .name_only
         .null_terminated
         .args('HEAD')
@@ -82,6 +83,7 @@ local function perform_stash(include)
   elseif include.index then
     local diff = 
       cli.diff
+        .no_ext_diff
         .cached
         .call() .. '\n'
 


### PR DESCRIPTION
Pressing tab on a file in the NeogitStatus popus would turn the arrow,
as if was open, but wouldn't show the diff. This happened when I
configured git diff to use an external diff tool like below

```
git config --global diff.external difft
```

This change disables external diffs in the status buffer