### PR TITLE
fix(cli): Use `--no-optional-locks`.

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -336,10 +336,11 @@ end
 
 local function exec(cmd, args, cwd, stdin, env, show_popup, hide_text)
   args = args or {}
-  if show_popup == nil then 
-    show_popup = true 
+  if show_popup == nil then
+    show_popup = true
   end
-  table.insert(args, 1, cmd)
+  table.insert(args, 1, "--no-optional-locks")
+  table.insert(args, 2, cmd)
 
   if not cwd then
     cwd = git_root()


### PR DESCRIPTION
From `man git(1)`:

```
       --no-optional-locks
           Do not perform optional operations that require locks. This is
           equivalent to setting the GIT_OPTIONAL_LOCKS to 0.

[...]

       GIT_OPTIONAL_LOCKS
           If set to 0, Git will complete any requested operation without
           performing any optional sub-operations that require taking a lock.
           For example, this will prevent git status from refreshing the index
           as a side effect. This is useful for processes running in the
           background which do not want to cause lock contention with other
           operations on the repository. Defaults to 1.
```

And from `man git-status(1)`:

```
BACKGROUND REFRESH
       By default, git status will automatically refresh the index, updating
       the cached stat information from the working tree and writing out the
       result. Writing out the updated index is an optimization that isn’t
       strictly necessary (status computes the values for itself, but writing
       them out is just to save subsequent programs from repeating our
       computation). When status is run in the background, the lock held
       during the write may conflict with other simultaneous processes,
       causing them to fail. Scripts running status in the background should
       consider using git --no-optional-locks status (see git(1) for details).
```