### PR TITLE
fix(status): Adjustments to 'Close' and 'GoToFile'.

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -82,6 +82,11 @@ function Buffer:close(force)
   if force == nil then
     force = false
   end
+  if self.kind == "tab" then
+    -- `silent!` as this might throw errors if 'hidden' is disabled.
+    vim.cmd("silent! 1only")
+    vim.cmd("try | tabn # | catch /.*/ | tabp | endtry")
+  end
   vim.api.nvim_buf_delete(self.handle, { force = force })
 end
 

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -755,10 +755,7 @@ end
 local cmd_func_map = function ()
   return {
     ["Close"] = function()
-      if M.status_buffer.kind == "tab" then
-        vim.cmd "1only"
-      end
-      vim.cmd "close"
+      M.status_buffer:close()
     end,
     ["Depth1"] = a.void(function()
       set_folds({ true, true, false })
@@ -818,14 +815,14 @@ local cmd_func_map = function ()
 
           local relpath = vim.fn.fnamemodify(repo_root .. '/' .. path, ':.')
 
-          if vim.fn.bufname() ~= "" then
-            vim.cmd("w")
+          if vim.bo.buftype == "" and not vim.bo.readonly and vim.fn.bufname() ~= "" then
+            vim.cmd("update")
           end
 
           vim.cmd("e " .. relpath)
 
           if hunk then
-            vim.cmd(":" .. hunk.disk_from)
+            vim.cmd(tostring(hunk.disk_from))
           end
 
         elseif vim.tbl_contains({ "unmerged", "unpulled", "recent", "stashes" }, section.name) then

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -815,7 +815,7 @@ local cmd_func_map = function ()
 
           local relpath = vim.fn.fnamemodify(repo_root .. '/' .. path, ':.')
 
-          if vim.bo.buftype == "" and not vim.bo.readonly and vim.fn.bufname() ~= "" then
+          if not vim.o.hidden and vim.bo.buftype == "" and not vim.bo.readonly and vim.fn.bufname() ~= "" then
             vim.cmd("update")
           end
 


### PR DESCRIPTION
- Avoids the "Already only one window" message that appears when you close a neogit tabpage, and there's only one window in the tabpage.
- Avoids errors when closing a neogit tabpage and it's the last tabpage.
- Avoids errors when closing a neogit tabpage, `'hidden'` is disabled and there are buffers with unsaved changes open in the tabpage.
- Avoids unnecessary writes on GoToFile (only write the current file if `'hidden'` is disabled and it's a normal, writeable buffer).