### PR TITLE
status: also display unmerged files

### DIFF
--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -38,6 +38,13 @@ local function update_status(state)
           table.insert(untracked_files, {
             name = rest,
           })
+        elseif kind == "u" then
+          local mode, _, _, _, _, _, _, _, _, name =
+            rest:match("(..) (....) (%d+) (%d+) (%d+) (%d+) (%w+) (%w+) (%w+) (.+)")
+          table.insert(untracked_files, {
+            mode = mode,
+            name = name,
+          })
         -- selene: allow(empty_if)
         elseif kind == "!" then
           -- we ignore ignored files for now


### PR DESCRIPTION
we currently don't display unmerged files (eg conflicted files) in git status. this fixes it.