### PR TITLE
feat(commit_view): Parse diffs for renamed files.

### DIFF
--- a/lua/neogit/buffers/commit_view/parsing.lua
+++ b/lua/neogit/buffers/commit_view/parsing.lua
@@ -24,7 +24,7 @@ function M.parse_commit_overview(raw)
   for i = 2, #raw - 1 do
     local file = {}
     if raw[i] ~= "" then
-      file.path, file.changes, file.insertions, file.deletions = raw[i]:match(" (.*)%s+|%s+(%d+) (%+*)(%-*)")
+      file.path, file.changes, file.insertions, file.deletions = raw[i]:match(" (.*)%s+|%s+(%d+) ?(%+*)(%-*)")
       table.insert(overview.files, file)
     end
   end

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -30,8 +30,11 @@ M.Diff = Component.new(function(diff)
   end)
 
   return col.tag("Diff") {
-    text(diff.kind .. " " .. diff.file),
-    col.tag("HunkList")(map(hunk_props, M.Hunk)),
+    text(diff.kind .. " " .. diff.file, { sign = "NeogitDiffHeader" }),
+    col.tag("DiffContent") {
+      col.tag("DiffInfo")(map(diff.info, text)),
+      col.tag("HunkList")(map(hunk_props, M.Hunk)),
+    },
   }
 end)
 

--- a/syntax/NeogitCommitView.vim
+++ b/syntax/NeogitCommitView.vim
@@ -12,9 +12,12 @@ hi def NeogitFilePath guifg=#798bf2
 
 hi def NeogitCommitViewHeader guifg=#ffffff guibg=#94bbd1
 
+hi def NeogitDiffHeader gui=bold
+
 sign define NeogitHunkHeader linehl=NeogitHunkHeader
 sign define NeogitHunkHeaderHighlight linehl=NeogitHunkHeaderHighlight
 
+sign define NeogitDiffHeader linehl=NeogitDiffHeader
 sign define NeogitDiffContextHighlight linehl=NeogitDiffContextHighlight
 sign define NeogitDiffAdd linehl=NeogitDiffAdd
 sign define NeogitDiffAddHighlight linehl=NeogitDiffAddHighlight


### PR DESCRIPTION
Parse diffs for renamed files in the commit view correctly.

I also added a highlight for the diff headers in the commit view (just `gui=bold`), as I felt that they blended in with the rest of the text.

<p>
<details>
<summary><b>Comparison with Magit:</b></summary>

| Neogit | Magit |
| --- | ----------- |
| <img src="https://user-images.githubusercontent.com/2786478/179023245-03868cdc-23e5-494a-86c4-684ab5ff0cec.png" width="450em"/> | <img src="https://user-images.githubusercontent.com/2786478/179026922-18081cd8-7aff-4b5e-9ab4-8ed85cb02e91.png" width="450em"/> |

</details>
</p>

