### PR TITLE
Make kind for all popups configurrable via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,16 @@ neogit.setup {
   auto_refresh = true,
   disable_builtin_notifications = false,
   use_magit_keybindings = false,
-  commit_popup = {
-      kind = "split",
-  },
   -- Change the default way of opening neogit
   kind = "tab",
+  -- Change the default way of opening the commit popup
+  commit_popup = {
+    kind = "split",
+  },
+  -- Change the default way of opening popups
+  popup = {
+    kind = "split",
+  },
   -- customize displayed signs
   signs = {
     -- { CLOSED, OPENED }

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -16,6 +16,9 @@ M.values = {
   commit_popup = {
     kind = "split",
   },
+  popup = {
+    kind = "split",
+  },
   signs = {
     hunk = { "", "" },
     item = { ">", "v" },

--- a/lua/neogit/lib/popup.lua
+++ b/lua/neogit/lib/popup.lua
@@ -4,6 +4,7 @@ local common = require("neogit.buffers.common")
 local Ui = require("neogit.lib.ui")
 local logger = require("neogit.logger")
 local util = require("neogit.lib.util")
+local config = require("neogit.config")
 
 local col = Ui.col
 local row = Ui.row
@@ -229,7 +230,7 @@ function M:show()
   self.buffer = Buffer.create {
     name = self.state.name,
     filetype = "NeogitPopup",
-    kind = "split",
+    kind = config.values.popup.kind,
     mappings = mappings,
     render = function()
       return {


### PR DESCRIPTION
`popups.kind` is a new config option in a similar vain to `kind` and `commit_popup.kind`.


This is the MR for https://github.com/TimUntersberger/neogit/issues/315


So with these settings
```
require("neogit").setup({
    popup = {
        kind = "vsplit",
    },
...
```
and pressing `c` in the neogit view I get this result:
![image](https://user-images.githubusercontent.com/79138/179391182-5b82636e-cff6-41dd-8a8d-56b9b9d9e4d6.png)
