### PR TITLE
fix(diffview): Use the `^!` notation to describe single-commit ranges.

### DIFF
--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -113,10 +113,10 @@ function M.open(section_name, item_name)
 
   if section_name == "recent" or section_name == "unmerged" or section_name == "log" then
     local commit_id = item_name:match("[a-f0-9]+")
-    view = dv_lib.diffview_open(dv_utils.tbl_pack(commit_id .. "^.." .. commit_id))
+    view = dv_lib.diffview_open(dv_utils.tbl_pack(commit_id .. "^!"))
   elseif section_name == "stashes" then
     local stash_id = item_name:match("stash@{%d+}")
-    view = dv_lib.diffview_open(dv_utils.tbl_pack(stash_id .. "^.." .. stash_id))
+    view = dv_lib.diffview_open(dv_utils.tbl_pack(stash_id .. "^!"))
   else
     view = get_local_diff_view(item_name)
   end


### PR DESCRIPTION
The `<SHA>^..<SHA>` format is unnecessarily verbose and doesn't work if
`<SHA>` has no parent commit. The `<REV>^!` format more accurately
describes the range of a single commit, and works regardless of the
number of parents.