### PR TITLE
Close popups with <esc>

### DIFF
--- a/lua/neogit/lib/popup.lua
+++ b/lua/neogit/lib/popup.lua
@@ -179,6 +179,9 @@ function M:show()
       ["q"] = function()
         self:close()
       end,
+      ["<esc>"] = function()
+        self:close()
+      end,
       ["<tab>"] = function()
         local stack = self.buffer.ui:get_component_stack_under_cursor()
 


### PR DESCRIPTION
Hi, and thanks everyone for awesome work on this plugin!

I recently started playing with it, and first thing I noticed is that it took me some time to figure out that popup should be closed with `q`. I think having `<esc>` as an option would be more convenient.