### PR TITLE
fix: check diff header length before parsing

### DIFF
--- a/lua/neogit/lib/git/diff.lua
+++ b/lua/neogit/lib/git/diff.lua
@@ -59,7 +59,7 @@ local function parse_diff(output, with_stats)
       table.insert(header, output[i])
     end
 
-    if header[2]:match("^similarity index") then
+    if #header >= 4 and header[2]:match("^similarity index") then
       diff.kind = "renamed"
       table.insert(diff.info, header[3])
       table.insert(diff.info, header[4])


### PR DESCRIPTION
Was causing #360. This should at least get rid of the error.