### PR TITLE
chore: update stylua-action version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: JohnnyMorganz/stylua-action@1.0.0
+      - uses: JohnnyMorganz/stylua-action@v1.1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --color always --check lua/ tests/


### PR DESCRIPTION
1.0.0 is broken and is causing the pipeline to fail.

This PR fixes back the pipeline.