### PR TITLE
chore: use uniform vim.cmd formatting

### DIFF
--- a/lua/neogit/buffers/commit_editor/init.lua
+++ b/lua/neogit/buffers/commit_editor/init.lua
@@ -49,10 +49,7 @@ function M:open()
             config.values.disable_commit_confirmation
             or input.get_confirmation("Are you sure you want to commit?")
           then
-            vim.cmd([[
-              silent g/^#/d
-              silent w!
-            ]])
+            vim.cmd("silent g/^#/d | silent w!")
           end
         end
 
@@ -75,7 +72,7 @@ function M:open()
       end
 
       -- NOTE: This avoids the user having to force to save the contents of the buffer.
-      vim.cmd([[silent w!]])
+      vim.cmd("silent w!")
     end,
   }
 end

--- a/lua/neogit/buffers/rebase_editor/init.lua
+++ b/lua/neogit/buffers/rebase_editor/init.lua
@@ -26,7 +26,7 @@ function M:open()
     autocmds = {
       ["BufUnload"] = function()
         self.on_close()
-        vim.cmd([[silent w!]])
+        vim.cmd("silent w!")
       end,
     },
     mappings = {
@@ -40,7 +40,7 @@ function M:open()
       buffer:set_lines(0, -1, false, self.content)
 
       -- NOTE: This avoids the user having to force to save the contents of the buffer.
-      vim.cmd([[silent w!]])
+      vim.cmd("silent w!")
     end,
   }
 end

--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -16,7 +16,7 @@ local old_config
 
 M.diffview_mappings = {
   close = function()
-    vim.cmd([[tabclose]])
+    vim.cmd("tabclose")
     neogit.dispatch_refresh()
     dv.setup(old_config)
   end,

--- a/lua/neogit/popups/commit.lua
+++ b/lua/neogit/popups/commit.lua
@@ -23,7 +23,7 @@ local function do_commit(popup, cmd)
 
   if result == 0 then
     notif.create("Successfully committed!")
-    vim.cmd([[do <nomodeline> User NeogitCommitComplete]])
+    vim.cmd("do <nomodeline> User NeogitCommitComplete")
   end
   a.util.scheduler()
   status.refresh(true)

--- a/lua/neogit/popups/push.lua
+++ b/lua/neogit/popups/push.lua
@@ -20,7 +20,7 @@ local function push_to(popup, name, remote, branch)
     logger.error("Pushed to " .. name)
     notif.create("Pushed to " .. name)
     status.refresh(true)
-    vim.cmd([[do <nomodeline> User NeogitPushComplete]])
+    vim.cmd("do <nomodeline> User NeogitPushComplete")
   else
     logger.error("Failed to push to " .. name)
   end

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -398,7 +398,7 @@ local function refresh(which)
     logger.debug("[STATUS BUFFER]: Refreshes completed")
     a.util.scheduler()
     refresh_status()
-    vim.cmd([[do <nomodeline> User NeogitStatusRefreshed]])
+    vim.cmd("do <nomodeline> User NeogitStatusRefreshed")
   end
 
   a.util.scheduler()


### PR DESCRIPTION
The double quote pattern is already dominant in the repo. This commit makes it uniform.
Keeping the multi brackets would come in handy for complex multiline commands or those in need of escape characters. 
But neither is the case here.