### PR TITLE
Remove hardcoded `q` for exit (to simplify having custom `q` mappings)

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -264,10 +264,6 @@ function Buffer.create(config)
     buffer:set_filetype(config.filetype)
   end
 
-  buffer.mmanager.mappings["q"] = function()
-    buffer:close()
-  end
-
   if config.mappings then
     for mode, val in pairs(config.mappings) do
       for key, cb in pairs(val) do


### PR DESCRIPTION
Before I was not able to remove default mapping from `q`

```lua
local neogit = require("neogit")
neogit.setup {
  mappings = {
    status = {
      ["q"] = "",
    }
  }
}
```

After this PR `q` will work the same (by default), but remapping `q` to `""` will also work.

For example, I use `q` for [Leap](https://github.com/ggandor/leap.nvim).
To force leap working inside neogit buffer I have to write autocomand around "NeogitStatusRefreshed".
Now I am able to just use the config above.
