### PR TITLE
Add custom option that allows to sort branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ neogit.setup {
   -- Neogit refreshes its internal state after specific events, which can be expensive depending on the repository size. 
   -- Disabling `auto_refresh` will make it so you have to manually refresh the status after you open it.
   auto_refresh = true,
+  -- Value used for `--sort` option for `git branch` command
+  -- By default, branches will be sorted by commit date descending
+  -- Flag description: https://git-scm.com/docs/git-branch#Documentation/git-branch.txt---sortltkeygt
+  -- Sorting keys: https://git-scm.com/docs/git-for-each-ref#_options
+  sort_branches = "-committerdate",
   disable_builtin_notifications = false,
   use_magit_keybindings = false,
   -- Change the default way of opening neogit

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -9,6 +9,7 @@ M.values = {
   disable_insert_on_commit = true,
   use_magit_keybindings = false,
   auto_refresh = true,
+  sort_branches = "-commiterdate",
   kind = "tab",
   -- The time after which an output console is shown for slow running commands
   console_timeout = 2000,

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -9,7 +9,7 @@ M.values = {
   disable_insert_on_commit = true,
   use_magit_keybindings = false,
   auto_refresh = true,
-  sort_branches = "-commiterdate",
+  sort_branches = "-committerdate",
   kind = "tab",
   -- The time after which an output console is shown for slow running commands
   console_timeout = 2000,

--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -1,6 +1,7 @@
 local a = require("plenary.async")
 local cli = require("neogit.lib.git.cli")
 local input = require("neogit.lib.input")
+local config = require("neogit.config")
 local M = {}
 
 local function parse_branches(branches, include_current)
@@ -21,7 +22,7 @@ local function parse_branches(branches, include_current)
 end
 
 function M.get_local_branches(include_current)
-  local branches = cli.branch.list.call_sync():trim().stdout
+  local branches = cli.branch.list(config.values.sort_branches).call_sync():trim().stdout
 
   return parse_branches(branches, include_current)
 end
@@ -33,7 +34,7 @@ function M.get_remote_branches(include_current)
 end
 
 function M.get_all_branches(include_current)
-  local branches = cli.branch.list.all.call_sync():trim().stdout
+  local branches = cli.branch.list(config.values.sort_branches).all.call_sync():trim().stdout
 
   return parse_branches(branches, include_current)
 end

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -201,7 +201,6 @@ local configurations = {
   },
   branch = config {
     flags = {
-      list = "--list",
       all = "-a",
       delete = "-d",
       remotes = "-r",
@@ -210,6 +209,11 @@ local configurations = {
       move = "-m",
     },
     aliases = {
+      list = function(tbl)
+	return function(sort)
+	  return tbl.args("--sort="..sort)
+	end
+      end,
       name = function(tbl)
         return function(name)
           return tbl.args(name)

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -210,9 +210,9 @@ local configurations = {
     },
     aliases = {
       list = function(tbl)
-	return function(sort)
-	  return tbl.args("--sort=" .. sort)
-	end
+        return function(sort)
+          return tbl.args("--sort=" .. sort)
+        end
       end,
       name = function(tbl)
         return function(name)

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -211,7 +211,7 @@ local configurations = {
     aliases = {
       list = function(tbl)
 	return function(sort)
-	  return tbl.args("--sort="..sort)
+	  return tbl.args("--sort=" .. sort)
 	end
       end,
       name = function(tbl)


### PR DESCRIPTION
When I checkout, I want to see branches sorted by commit date. 
This change allows user to specify their own sort settings.

Flag description: https://git-scm.com/docs/git-branch#Documentation/git-branch.txt---sortltkeygt
Sorting keys: https://git-scm.com/docs/git-for-each-ref#_options

#144 #392