### PR TITLE
Added the ability to set the kind of buffer used for preview_buffer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ neogit.setup {
   commit_popup = {
     kind = "split",
   },
+  -- Change the default way of opening the preview buffer
+  preview_buffer = {
+    kind = "split",
+  },
   -- Change the default way of opening popups
   popup = {
     kind = "split",

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -20,6 +20,9 @@ M.values = {
   commit_popup = {
     kind = "split",
   },
+  preview_buffer = {
+    kind = "split",
+  },
   popup = {
     kind = "split",
   },

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -5,7 +5,6 @@ local Buffer = require("neogit.lib.buffer")
 local config = require("neogit.config")
 local logger = require("neogit.logger")
 
-
 local function remove_escape_codes(s)
   -- from: https://stackoverflow.com/questions/48948630/lua-ansi-escapes-pattern
 
@@ -61,13 +60,13 @@ end
 local preview_buffer = nil
 
 local function create_preview_buffer()
-  kind = config.values.preview_buffer.kind
+  local kind = config.values.preview_buffer.kind
 
   -- May be called multiple times due to scheduling
   if preview_buffer then
     if preview_buffer.buffer then
-        logger.debug("Preview buffer already exists. Focusing the existing one")
-        preview_buffer.buffer:focus()
+      logger.debug("Preview buffer already exists. Focusing the existing one")
+      preview_buffer.buffer:focus()
     end
     return
   end

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -2,6 +2,9 @@ local a = require("plenary.async")
 local notification = require("neogit.lib.notification")
 
 local Buffer = require("neogit.lib.buffer")
+local config = require("neogit.config")
+local logger = require("neogit.logger")
+
 
 local function remove_escape_codes(s)
   -- from: https://stackoverflow.com/questions/48948630/lua-ansi-escapes-pattern
@@ -58,8 +61,14 @@ end
 local preview_buffer = nil
 
 local function create_preview_buffer()
+  kind = config.values.preview_buffer.kind
+
   -- May be called multiple times due to scheduling
   if preview_buffer then
+    if preview_buffer.buffer then
+        logger.debug("Preview buffer already exists. Focusing the existing one")
+        preview_buffer.buffer:focus()
+    end
     return
   end
 
@@ -73,7 +82,7 @@ local function create_preview_buffer()
     name = name,
     bufhidden = "hide",
     filetype = "NeogitConsole",
-    kind = "split",
+    kind = kind,
     open = false,
     mappings = {
       n = {
@@ -126,9 +135,7 @@ local function scroll_to_end(win)
 end
 
 function Process.show_console()
-  if not preview_buffer then
-    create_preview_buffer()
-  end
+  create_preview_buffer()
 
   local win = preview_buffer.buffer:show()
   scroll_to_end(win)
@@ -155,14 +162,10 @@ local function append_log(process, data)
     nvim_chan_send(preview_buffer.chan, data .. "\r\n")
   end
 
-  if not preview_buffer then
-    vim.schedule(function()
-      create_preview_buffer()
-      append()
-    end)
-  else
+  vim.schedule(function()
+    create_preview_buffer()
     append()
-  end
+  end)
 end
 
 local hide_console = false
@@ -178,7 +181,6 @@ function Process.hide_preview_buffers()
   end
 end
 
-local config = require("neogit.config")
 function Process:start_timer()
   if self.timer == nil then
     local timer = vim.loop.new_timer()
@@ -376,7 +378,6 @@ function Process:spawn(cb)
     end
   end
 
-  local logger = require("neogit.logger")
   logger.debug("Spawning: " .. vim.inspect(self.cmd))
   local job = vim.fn.jobstart(self.cmd, {
     cwd = self.cwd,


### PR DESCRIPTION
Ended up resolving #445 by myself. Basically, I added a new configuration option preview_buffer.kind which will allow the user to select what kind of buffer the preview_buffer/NeogitConsole renders as. While doing this I also resolved an issue where if the preview_buffer as a floating window was unfocused it could not be re-focused again after it loses focus.