### PR TITLE
Make all file modes equal length in Status

### DIFF
--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -85,14 +85,14 @@ local function get_current_section_item()
 end
 
 local mode_to_text = {
-  M  = "Modified     ",
-  N  = "New file     ",
-  A  = "Added        ",
-  D  = "Deleted      ",
-  C  = "Copied       ",
-  U  = "Updated      ",
+  M = "Modified     ",
+  N = "New file     ",
+  A = "Added        ",
+  D = "Deleted      ",
+  C = "Copied       ",
+  U = "Updated      ",
   UU = "Both Modified",
-  R  = "Renamed      ",
+  R = "Renamed      ",
 }
 
 local function draw_sign_for_item(item, name)

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -85,14 +85,14 @@ local function get_current_section_item()
 end
 
 local mode_to_text = {
-  M = "Modified",
-  N = "New file",
-  A = "Added",
-  D = "Deleted",
-  C = "Copied",
-  U = "Updated",
+  M  = "Modified     ",
+  N  = "New file     ",
+  A  = "Added        ",
+  D  = "Deleted      ",
+  C  = "Copied       ",
+  U  = "Updated      ",
   UU = "Both Modified",
-  R = "Renamed",
+  R  = "Renamed      ",
 }
 
 local function draw_sign_for_item(item, name)

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -169,10 +169,15 @@ local function draw_buffer()
       location.files = {}
 
       for _, f in ipairs(data.items) do
+        local label = mode_to_text[f.mode]
+        if vim.o.columns < 120 then
+          label = vim.trim(label)
+        end
+
         if f.mode and f.original_name then
-          output:append(string.format("%s %s -> %s", mode_to_text[f.mode], f.original_name, f.name))
+          output:append(string.format("%s %s -> %s", label, f.original_name, f.name))
         elseif f.mode then
-          output:append(string.format("%s %s", mode_to_text[f.mode], f.name))
+          output:append(string.format("%s %s", label, f.name))
         else
           output:append(f.name)
         end

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -170,7 +170,7 @@ local function draw_buffer()
 
       for _, f in ipairs(data.items) do
         local label = mode_to_text[f.mode]
-        if vim.o.columns < 120 then
+        if label and vim.o.columns < 120 then
           label = vim.trim(label)
         end
 


### PR DESCRIPTION
This is a fairly small change, the effect of which is to vertically align filepaths in the status window:

<img width="834" alt="Screenshot 2023-02-25 at 13 04 42" src="https://user-images.githubusercontent.com/7228095/221355907-362836b5-18c1-4f0b-b32d-1205840cc73b.png">

Compare that with how it is now:
<img width="752" alt="Screenshot 2023-02-25 at 13 07 18" src="https://user-images.githubusercontent.com/7228095/221355984-ef2252de-71c9-4ee4-9c5e-3ab814874f52.png">

Much more readable!

(ignore the colors - thats just some fun I'm having)
