### PR TITLE
Refactor diff.lua to speed up large files in index

### DIFF
--- a/lua/neogit/lib/git/diff.lua
+++ b/lua/neogit/lib/git/diff.lua
@@ -233,7 +233,7 @@ function diff.register(meta)
 
     for _, f in ipairs(repo.staged.items) do
       if f.mode ~= "D" and f.mode ~= "F" and (not filter or filter:accepts("staged", f.name)) then
-        table.insert(executions, function()
+        insert(executions, function()
           local raw_diff = cli.diff.no_ext_diff.cached.files(f.name).call():trim().stdout
           local raw_stats = cli.diff.no_ext_diff.cached.shortstat.files(f.name).call():trim().stdout
           f.diff = parse_diff(raw_diff)

--- a/lua/neogit/lib/git/diff.lua
+++ b/lua/neogit/lib/git/diff.lua
@@ -59,15 +59,11 @@ local function build_type(header)
 
     info = { header[3], header[4] }
 
-    file = ("%s -> %s"):format(
-      info[1]:match("rename from (.*)"),
-      info[2]:match("rename to (.*)")
-    )
+    file = ("%s -> %s"):format(info[1]:match("rename from (.*)"), info[2]:match("rename to (.*)"))
   else
     if header_count == 4 then
       -- kind = modified
       file = header[3]:match("%-%-%- a/(.*)")
-
     elseif header_count == 5 then
       kind = header[2]:match("(.*) mode %d+")
 
@@ -160,7 +156,7 @@ local function parse_diff(output)
         self.hunks = self._hunks()
         return self.hunks
       end
-    end
+    end,
   }
 
   local diff = {


### PR DESCRIPTION
I did some profiling for the general sluggishness when a very large file is present in the index, and it came up that `parse_diff()` was the culprit. From there, I started teasing the different functions out of that larger one to find where the problem came from, and low-and-behold, it was building hunks.

So, with some metatable magic, we can defer computing the hunks until somebody tries to actually _render_ it. That way, if you are just doing some staging/committing with the folds closed, you never pay for something that you never see.

I did change a couple things beyond that, though:

1. `parse_diff()` took a second argument, `with_stats`, but I couldn't find a single caller who actually passed that argument. So, it's removed.
2. Replacing calls to `vim.startswith("...")` with `<string>:match("^...")`. Profiling called these out as hot-spots, as you can see below.

I haven't done a lot with metatables/lazy-evaluation in Lua before, so if there are ways to improve it, I'm all ears.

To test the effect of this, on master, make a file with 10,000-20,000+ lines, open neogit, and stage it. Wait. Close neogit, reopen it, wait some more. Then checkout this branch, and observe the lack of waiting.

For compairison, here's a profile of staging and unstaging a (folded) 100,000 line file on current master:
![Screenshot 2023-03-01 at 11 06 25](https://user-images.githubusercontent.com/7228095/222108707-b8c3e0ca-617e-46cb-9582-cf363e9cb220.png)

Mind you, we never actually _rendered_ the diff, so all this is wasted work.

Here's this branch, same action, same file:
![Screenshot 2023-03-01 at 11 06 59](https://user-images.githubusercontent.com/7228095/222108837-9300ddcc-1783-44e9-9946-2dc6f2e321eb.png)

Of course, if the user goes to render the diff, then all this work still needs to be performed. But one problem at a time :)
