### PR TITLE
Fixed issue with remote client on Windows

### DIFF
--- a/lua/neogit/client.lua
+++ b/lua/neogit/client.lua
@@ -9,7 +9,7 @@ function M.get_nvim_remote_editor()
   local nvim_path = fn.shellescape(vim.v.progpath)
 
   local runtimepath_cmd = fn.shellescape(fmt("set runtimepath^=%s", fn.fnameescape(tostring(neogit_path))))
-  local lua_cmd = fn.shellescape('lua require("neogit.client").client()')
+  local lua_cmd = fn.shellescape("lua require('neogit.client').client()")
 
   local shell_cmd = {
     nvim_path,
@@ -47,6 +47,10 @@ function M.client()
 
   local client = fn.serverstart()
   local lua_cmd = fmt('lua require("neogit.client").editor("%s", "%s")', file_target, client)
+
+  if vim.loop.os_uname().sysname == "Windows_NT" then
+    lua_cmd = lua_cmd:gsub("\\","/")
+  end
 
   local rpc_server = RPC.create_connection(nvim_server)
   rpc_server:send_cmd(lua_cmd)

--- a/lua/neogit/client.lua
+++ b/lua/neogit/client.lua
@@ -49,7 +49,7 @@ function M.client()
   local lua_cmd = fmt('lua require("neogit.client").editor("%s", "%s")', file_target, client)
 
   if vim.loop.os_uname().sysname == "Windows_NT" then
-    lua_cmd = lua_cmd:gsub("\\","/")
+    lua_cmd = lua_cmd:gsub("\\", "/")
   end
 
   local rpc_server = RPC.create_connection(nvim_server)


### PR DESCRIPTION
 This PR is fixes issue #424

There was only two issues, and all of them in `lua/neogit/client.lua`

First one is: wrong quotes in `neogit.client.get_nvim_remote_editor()` at line 12. This caused neovim command look like this: `-c "lua require(""neogit.client"").client()` (note extra quotes around `neogit.client`)

Second issue is in `neogit.client.client()`. In `file_target` and `client` variables was unescaped reversed slashes `\`. 

P.S. Sorry for bad English 😅 