### PR TITLE
Syntax: Object ID's are followed by a space

### DIFF
--- a/syntax/NeogitStatus.vim
+++ b/syntax/NeogitStatus.vim
@@ -4,7 +4,7 @@ endif
 " Support the rebase todo highlights
 source $VIMRUNTIME/syntax/gitrebase.vim
 
-syn match NeogitObjectId /^[a-z0-9]\{7,}\>/
+syn match NeogitObjectId /^[a-z0-9]\{7,}\>\s/
 syn match NeogitCommitMessage /.*/ contained
 syn match NeogitBranch /\S\+/ contained nextgroup=NeogitCommitMessage
 syn match NeogitRemote /\S\+/ contained nextgroup=NeogitCommitMessage


### PR DESCRIPTION
The `NeogitObjectId` was a bit too greedy and matches stuff it shouldn't, like `profiles` and `queries` below.
![Screenshot 2023-03-07 at 12 56 51](https://user-images.githubusercontent.com/7228095/223415692-5f9146dc-372a-49d2-adc5-a0f298b2a197.png)


Since an object id is followed by a space, we can make the regex a bit more specific:

![Screenshot 2023-03-07 at 13 00 37](https://user-images.githubusercontent.com/7228095/223416244-9910f180-f04c-48bf-b226-43190ee5921f.png)

