### PR TITLE
MD5 Hash state file to prevent issues on windows

### DIFF
--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -13,7 +13,7 @@ end
 
 ---@return Path
 function M.filepath()
-  local base_path = vim.fs.normalize(vim.fn.stdpath("state") .. "/neogit/")
+  local base_path = vim.fn.stdpath("state") .. "/neogit/"
   local filename = "state"
 
   if config.values.use_per_project_settings then

--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -1,6 +1,7 @@
 local logger = require("neogit.logger")
 local config = require("neogit.config")
 local Path = require("plenary.path")
+local sumhexa = require("neogit.lib.md5").sumhexa
 
 local M = {}
 
@@ -12,11 +13,11 @@ end
 
 ---@return Path
 function M.filepath()
-  local base_path = vim.fn.stdpath("state") .. "/neogit/"
+  local base_path = vim.fs.normalize(vim.fn.stdpath("state") .. "/neogit/")
   local filename = "state"
 
   if config.values.use_per_project_settings then
-    filename = vim.loop.cwd():gsub("/", "%%")
+    filename = sumhexa(vim.loop.cwd())
   end
 
   return Path:new(base_path .. filename)

--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -13,14 +13,10 @@ end
 
 ---@return Path
 function M.filepath()
-  local base_path = vim.fn.stdpath("state") .. "/neogit/"
-  local filename = "state"
-
-  if config.values.use_per_project_settings then
-    filename = sumhexa(vim.loop.cwd())
-  end
-
-  return Path:new(base_path .. filename)
+  local base_path = vim.fn.stdpath("state") .. Path.path.sep .. "neogit"
+  local filename = sumhexa(config.values.use_per_project_settings and vim.loop.cwd() or "state")
+  
+  return Path:new(base_path .. Path.path.sep .. filename)
 end
 
 ---Initializes state


### PR DESCRIPTION
Pretty simple, just pass the `cwd` string into md5 to get a valid filepath for windows/mac/etc