### PR TITLE
fix: partition diff checks to prevent too many open files error

### DIFF
--- a/lua/neogit/lib/collection.lua
+++ b/lua/neogit/lib/collection.lua
@@ -68,6 +68,19 @@ function M.find(tbl, func)
   return nil
 end
 
+function M.partition(tbl, max)
+  local res = { {} }
+  local i = 1
+  for j, item in ipairs(tbl) do
+    if j % max == 0 then
+      table.insert(res, {})
+      i = i + 1
+    end
+    table.insert(res[i], item)
+  end
+  return res
+end
+
 return setmetatable(M, {
   __call = function(_, tbl)
     return M.new(tbl)


### PR DESCRIPTION
If there are many staged or unstaged files in the repo, each of these would have a `git diff` check performed on them. This caused the error "too many open files" because too many async requests were being done at a time.

This change partitions these `git diff` calls to be done in chunks of 50, which during testing did not cause the error.