### PR TITLE
Upstreaming 3/n - Popup/Builder libs

### DIFF
--- a/lua/neogit/lib/popup.lua
+++ b/lua/neogit/lib/popup.lua
@@ -6,12 +6,19 @@ local logger = require("neogit.logger")
 local util = require("neogit.lib.util")
 local config = require("neogit.config")
 local state = require("neogit.lib.state")
+local input = require("neogit.lib.input")
+
+local branch = require("neogit.lib.git.branch")
+local config_lib = require("neogit.lib.git.config")
 
 local col = Ui.col
 local row = Ui.row
 local text = Ui.text
 local Component = Ui.Component
 local map = util.map
+local filter_map = util.filter_map
+local build_reverse_lookup = util.build_reverse_lookup
+local intersperse = util.intersperse
 local List = common.List
 local Grid = common.Grid
 
@@ -33,27 +40,28 @@ end
 ---@return string[]
 function M:get_arguments()
   local flags = {}
-  for _, switch in pairs(self.state.switches) do
-    if switch.enabled and switch.parse ~= false then
-      table.insert(flags, "--" .. switch.cli)
+
+  for _, arg in pairs(self.state.args) do
+    if arg.type == "switch" and arg.enabled and not arg.internal then
+      table.insert(flags, arg.cli_prefix .. arg.cli)
+    end
+
+    if arg.type == "option" and #arg.value ~= 0 and not arg.internal then
+      table.insert(flags, arg.cli_prefix .. arg.cli .. "=" .. arg.value)
     end
   end
-  for _, option in pairs(self.state.options) do
-    if #option.value ~= 0 and option.parse ~= false then
-      table.insert(flags, "--" .. option.cli .. "=" .. option.value)
-    end
-  end
+
   return flags
 end
 
-function M:get_parse_arguments()
-  local switches = {}
-  for _, switch in pairs(self.state.switches) do
-    if switch.enabled and switch.parse then
-      switches[switch.cli] = switch.enabled
+function M:get_internal_arguments()
+  local args = {}
+  for _, arg in pairs(self.state.args) do
+    if arg.type == "switch" and arg.enabled and arg.internal then
+      args[arg.cli] = true
     end
   end
-  return switches
+  return args
 end
 
 function M:to_cli()
@@ -81,97 +89,280 @@ local function get_highlight_for_option(option)
   return "NeogitPopupOptionDisabled"
 end
 
+local function get_highlight_for_config(config)
+  if config.value and config.value ~= "" and config.value ~= "unset" then
+    return config.type or "NeogitPopupConfigEnabled"
+  end
+
+  return "NeogitPopupConfigDisabled"
+end
+
+local function construct_config_options(config)
+  local options = filter_map(config.options, function(option)
+    if option.display == "" then
+      return
+    end
+
+    local highlight
+    if config.value == option.value then
+      highlight = "NeogitPopupConfigEnabled"
+    else
+      highlight = "NeogitPopupConfigDisabled"
+    end
+
+    return text.highlight(highlight)(option.display)
+  end)
+
+  local value = intersperse(options, text.highlight("NeogitPopupConfigDisabled")("|"))
+  table.insert(value, 1, text.highlight("NeogitPopupConfigDisabled")("["))
+  table.insert(value, #value + 1, text.highlight("NeogitPopupConfigDisabled")("]"))
+
+  return value
+end
+
+function M:update_component(id, highlight, value)
+  local component = self.buffer.ui:find_component(function(c)
+    return c.options.id == id
+  end)
+
+  assert(component, "Component not found! Cannot update.")
+
+  if highlight then
+    if component.options.highlight then
+      component.options.highlight = highlight
+    else
+      component.children[1].options.highlight = highlight
+    end
+  end
+
+  if value then
+    if type(value) == "string" then
+      component.children[#component.children].value = value
+    elseif type(value) == "table" then
+      -- Remove last n children from row
+      for _ = 1, #value do
+        table.remove(component.children)
+      end
+
+      -- insert new items to row
+      for _, text in ipairs(value) do
+        table.insert(component.children, text)
+      end
+    else
+      print("Unhandled component value type! (" .. type(value) .. ")")
+    end
+  end
+
+  self.buffer.ui:update()
+end
+
 function M:toggle_switch(switch)
   switch.enabled = not switch.enabled
-  local c = self.buffer.ui:find_component(function(c)
-    return c.options.id == switch.id
-  end)
-  c.options.highlight = get_highlight_for_switch(switch)
+
+  if switch.user_input then
+    if switch.enabled then
+      local value = input.get_user_input(switch.cli_prefix .. switch.cli_base .. ": ")
+      if value then
+        switch.cli = switch.cli_base .. value
+      end
+    else
+      switch.cli = switch.cli_base
+    end
+  end
+
   state.set({ self.state.name, switch.cli }, switch.enabled)
-  self.buffer.ui:update()
+  self:update_component(switch.id, get_highlight_for_switch(switch), switch.cli)
+
+  if switch.enabled and #switch.incompatible > 0 then
+    for _, var in ipairs(self.state.args) do
+      if var.type == "switch" and var.enabled and switch.incompatible[var.cli] then
+        var.enabled = false
+        state.set({ self.state.name, var.cli }, var.enabled)
+        self:update_component(var.id, get_highlight_for_switch(var))
+      end
+    end
+  end
 end
 
 function M:set_option(option)
-  option.value = vim.fn.input {
-    prompt = option.cli .. "=",
-    default = option.value,
-    cancelreturn = option.value,
-  }
-  local c = self.buffer.ui:find_component(function(c)
-    return c.options.id == option.id
-  end)
-  c.options.highlight = get_highlight_for_option(option)
-  c.children[#c.children].value = option.value
-  state.set({ self.state.name, option.cli }, option.value)
-  self.buffer.ui:update()
+  local set = function(value)
+    option.value = value
+    state.set({ self.state.name, option.cli }, option.value)
+    self:update_component(option.id, get_highlight_for_option(option), option.value)
+  end
+
+  if option.choices then
+    if not option.value or option.value == "" then
+      vim.ui.select(option.choices, { prompt = option.description }, set)
+    else
+      set("")
+    end
+  else
+    local input =
+      vim.fn.input { prompt = option.cli .. "=", default = option.value, cancelreturn = option.value }
+
+    if option.default and input == "" then
+      set(option.default)
+    else
+      set(input)
+    end
+  end
 end
 
-local Switches = Component.new(function(props)
-  return col {
-    text.highlight("NeogitPopupSectionTitle")("Switches"),
-    col(map(props.state, function(switch)
-      return row.tag("Switch").value(switch) {
-        row.highlight("NeogitPopupSwitchKey") {
-          text(" -"),
-          text(switch.key),
-        },
-        text(" "),
-        text(switch.description),
-        text(" ("),
-        row.id(switch.id).highlight(get_highlight_for_switch(switch)) {
-          text("--"),
-          text(switch.cli),
-        },
-        text(")"),
-      }
-    end)),
+function M:set_config(config)
+  if config.options then
+    local options = build_reverse_lookup(map(config.options, function(option)
+      return option.value
+    end))
+
+    local index = options[config.value]
+    config.value = options[(index + 1)] or options[1]
+    self:update_component(config.id, nil, construct_config_options(config))
+  elseif config.callback then
+    config.callback(self, config)
+    -- block here?
+  else
+    local result = vim.fn.input {
+      prompt = config.name .. " > ",
+      default = config.value == "unset" and "" or config.value,
+      cancelreturn = config.value,
+    }
+
+    config.value = result == "" and "unset" or result
+    self:update_component(config.id, get_highlight_for_config(config), config.value)
+  end
+
+  config_lib.set(config.name, config.value)
+
+  -- Updates passive variables (variables that don't get interacted with directly)
+  for _, var in ipairs(self.state.config) do
+    if var.passive then
+      local c_value = config_lib.get(var.name)
+      if c_value then
+        var.value = c_value.value
+        self:update_component(var.id, nil, var.value)
+      end
+    end
+  end
+end
+
+local Switch = Component.new(function(switch)
+  return row.tag("Switch").value(switch) {
+    text(" "),
+    row.highlight("NeogitPopupSwitchKey") {
+      text(switch.key_prefix),
+      text(switch.key),
+    },
+    text(" "),
+    text(switch.description),
+    text(" ("),
+    row.id(switch.id).highlight(get_highlight_for_switch(switch)) {
+      text(switch.cli_prefix),
+      text(switch.cli),
+    },
+    text(")"),
   }
 end)
 
-local Options = Component.new(function(props)
-  return col {
-    text.highlight("NeogitPopupSectionTitle")("Options"),
-    col(map(props.state, function(option)
-      return row.tag("Option").value(option) {
-        row.highlight("NeogitPopupOptionKey") {
-          text(" ="),
-          text(option.key),
-        },
-        text(" "),
-        text(option.description),
-        text(" ("),
-        row.id(option.id).highlight(get_highlight_for_option(option)) {
-          text("--"),
-          text(option.cli),
-          text("="),
-          text(option.value or ""),
-        },
-        text(")"),
-      }
-    end)),
+local Option = Component.new(function(option)
+  return row.tag("Option").value(option) {
+    text(" "),
+    row.highlight("NeogitPopupOptionKey") {
+      text(option.key_prefix),
+      text(option.key),
+    },
+    text(" "),
+    text(option.description),
+    text(" ("),
+    row.id(option.id).highlight(get_highlight_for_option(option)) {
+      text(option.cli_prefix),
+      text(option.cli),
+      text("="),
+      text(option.value or ""),
+    },
+    text(")"),
   }
+end)
+
+local Section = Component.new(function(title, items)
+  return col {
+    text.highlight("NeogitPopupSectionTitle")(title),
+    col(items),
+  }
+end)
+
+local Config = Component.new(function(props)
+  local c = {}
+
+  if not props.state[1].heading then
+    table.insert(c, text.highlight("NeogitPopupSectionTitle")("Variables"))
+  end
+
+  table.insert(
+    c,
+    col(map(props.state, function(config)
+      if config.heading then
+        return row.highlight("NeogitPopupSectionTitle") { text(config.heading) }
+      end
+
+      local value
+      if config.options then
+        value = construct_config_options(config)
+      else
+        local value_text
+        if not config.value or config.value == "" then
+          value_text = "unset"
+        else
+          value_text = config.value
+        end
+
+        value = { text.highlight(get_highlight_for_config(config))(value_text) }
+      end
+
+      local key
+      if config.passive then
+        key = " "
+      elseif #config.key > 1 then
+        key = table.concat(vim.split(config.key, ""), " ")
+      else
+        key = config.key
+      end
+
+      return row.tag("Config").value(config) {
+        text(" "),
+        row.highlight("NeogitPopupConfigKey") { text(key) },
+        text(" " .. config.name .. " "),
+        row.id(config.id) { unpack(value) },
+      }
+    end))
+  )
+
+  return col(c)
 end)
 
 local Actions = Component.new(function(props)
   return col {
-    text.highlight("NeogitPopupSectionTitle")("Actions"),
     Grid.padding_left(1) {
       items = props.state,
-      gap = 1,
+      gap = 3,
       render_item = function(item)
-        if not item.callback then
+        if item.heading then
+          return row.highlight("NeogitPopupSectionTitle") { text(item.heading) }
+        elseif not item.callback then
           return row.highlight("NeogitPopupActionDisabled") {
+            text(" "),
             text(item.key),
             text(" "),
             text(item.description),
           }
+        else
+          return row {
+            text(" "),
+            text.highlight("NeogitPopupActionKey")(item.key),
+            text(" "),
+            text(item.description),
+          }
         end
-
-        return row {
-          text.highlight("NeogitPopupActionKey")(item.key),
-          text(" "),
-          text(item.description),
-        }
       end,
     },
   }
@@ -193,6 +384,9 @@ function M:show()
           if x.options.tag == "Switch" then
             self:toggle_switch(x.options.value)
             break
+          elseif x.options.tag == "Config" then
+            self:set_config(x.options.value)
+            break
           elseif x.options.tag == "Option" then
             self:set_option(x.options.value)
             break
@@ -202,21 +396,35 @@ function M:show()
     },
   }
 
-  for _, switch in pairs(self.state.switches) do
-    mappings.n[switch.id] = function()
-      self:toggle_switch(switch)
+  for _, arg in pairs(self.state.args) do
+    if arg.id then
+      mappings.n[arg.id] = function()
+        if arg.type == "switch" then
+          self:toggle_switch(arg)
+        elseif arg.type == "option" then
+          self:set_option(arg)
+        end
+      end
     end
   end
 
-  for _, option in pairs(self.state.options) do
-    mappings.n[option.id] = function()
-      self:set_option(option)
+  for _, config in pairs(self.state.config) do
+    -- selene: allow(empty_if)
+    if config.heading then
+      -- nothing
+    elseif not config.passive then
+      mappings.n[config.id] = function()
+        self:set_config(config)
+      end
     end
   end
 
   for _, group in pairs(self.state.actions) do
     for _, action in pairs(group) do
-      if action.callback then
+      -- selene: allow(empty_if)
+      if action.heading then
+        -- nothing
+      elseif action.callback then
         mappings.n[action.key] = function()
           logger.debug(string.format("[POPUP]: Invoking action '%s' of %s", action.key, self.state.name))
           local ret = action.callback(self)
@@ -236,12 +444,29 @@ function M:show()
 
   local items = {}
 
-  if self.state.switches[1] then
-    table.insert(items, Switches { state = self.state.switches })
+  if self.state.config[1] then
+    table.insert(items, Config { state = self.state.config })
   end
 
-  if self.state.options[1] then
-    table.insert(items, Options { state = self.state.options })
+  if self.state.args[1] then
+    local section = {}
+    local name = "Arguments"
+    for _, item in ipairs(self.state.args) do
+      if item.type == "option" then
+        table.insert(section, Option(item))
+      elseif item.type == "switch" then
+        table.insert(section, Switch(item))
+      elseif item.type == "heading" then
+        if section[1] then -- If there are items in the section, flush to items table with current name
+          table.insert(items, Section(name, section))
+          section = {}
+        end
+
+        name = item.heading
+      end
+    end
+
+    table.insert(items, Section(name, section))
   end
 
   if self.state.actions[1] then
@@ -253,11 +478,12 @@ function M:show()
     filetype = "NeogitPopup",
     kind = config.values.popup.kind,
     mappings = mappings,
-    after = function(buffer)
+    after = function()
+      vim.cmd([[setlocal nocursorline]])
+      vim.fn.matchadd("NeogitPopupBranchName", self.state.env.highlight or branch.current(), 100)
+
       if config.values.popup.kind == "split" then
-        vim.api.nvim_buf_call(buffer.handle, function()
-          vim.cmd([[execute "resize" . (line("$") + 1)]])
-        end)
+        vim.cmd([[execute "resize" . (line("$") + 1)]])
       end
     end,
     render = function()
@@ -271,7 +497,4 @@ function M:show()
   }
 end
 
-M.deprecated_create = require("neogit.lib.popup.lib").create
-
 return M
--- return require("neogit.lib.popup.lib")

--- a/lua/neogit/lib/popup/builder.lua
+++ b/lua/neogit/lib/popup/builder.lua
@@ -33,11 +33,18 @@ function M:env(x)
   return self
 end
 
+-- Adds new column to actions section of popup
+---@param heading string|nil
+---@return self
 function M:new_action_group(heading)
   table.insert(self.state.actions, { { heading = heading or "" } })
   return self
 end
 
+-- Conditionally adds new column to actions section of popup
+---@param cond boolean
+---@param heading string|nil
+---@return self
 function M:new_action_group_if(cond, heading)
   if cond then
     return self:new_action_group(heading)
@@ -46,11 +53,18 @@ function M:new_action_group_if(cond, heading)
   return self
 end
 
+-- Adds new heading to current column within actions section of popup
+---@param heading string
+---@return self
 function M:group_heading(heading)
   table.insert(self.state.actions[#self.state.actions], { heading = heading })
   return self
 end
 
+-- Conditionally adds new heading to current column within actions section of popup
+---@param cond boolean
+---@param heading string
+---@return self
 function M:group_heading_if(cond, heading)
   if cond then
     return self:group_heading(heading)
@@ -59,8 +73,20 @@ function M:group_heading_if(cond, heading)
   return self
 end
 
+---@param key string Which key triggers switch
+---@param cli string Git cli flag to use
+---@param description string Description text to show user
+---@param opts table|nil A table of options for the switch
+---@param opts.enabled boolean Controls if the switch should default to 'on' state
 ---@param opts.internal boolean Whether the switch is internal to neogit or should be included in the cli command.
 --                              If `true` we don't include it in the cli comand.
+---@param opts.incompatible table A table of strings that represent other cli flags that this one cannot be used with
+---@param opts.key_prefix string Allows overwriting the default '-' to toggle switch
+---@param opts.cli_prefix string Allows overwriting the default '--' thats used to create the cli flag. Sometimes you may want
+--                               to use '++' or '-'.
+---@param opts.value string Allows for pre-building cli flags that can be customised by user input
+---@param opts.user_input boolean If true, allows user to customise the value of the cli flag
+---@return self
 function M:switch(key, cli, description, opts)
   opts = opts or {}
 
@@ -109,6 +135,10 @@ function M:switch(key, cli, description, opts)
   return self
 end
 
+-- Conditionally adds a switch.
+---@see M:switch
+---@param cond boolean
+---@return self
 function M:switch_if(cond, key, cli, description, opts)
   if cond then
     return self:switch(key, cli, description, opts)
@@ -117,6 +147,15 @@ function M:switch_if(cond, key, cli, description, opts)
   return self
 end
 
+---@param key string Key for the user to engage option
+---@param cli string CLI value used
+---@param value string Current value of option
+---@param description string Description of option, presented to user
+---@param opts table|nil
+---@param opts.key_prefix string Allows overwriting the default '=' to set option
+---@param opts.cli_prefix string Allows overwriting the default '--' cli prefix
+---@param opts.choices table Table of predefined choices that a user can select for option
+---@param opts.default string|integer|boolean Default value for option, if the user attempts to unset value
 function M:option(key, cli, value, description, opts)
   opts = opts or {}
 
@@ -144,11 +183,17 @@ function M:option(key, cli, value, description, opts)
   return self
 end
 
+-- Adds heading text within Arguments (options/switches) section of popup
+---@param heading string Heading to show
+---@return self
 function M:arg_heading(heading)
   table.insert(self.state.args, { type = "heading", heading = heading })
   return self
 end
 
+---@see M:option
+---@param cond boolean
+---@return self
 function M:option_if(cond, key, cli, value, description, opts)
   if cond then
     return self:option(key, cli, value, description, opts)
@@ -157,11 +202,22 @@ function M:option_if(cond, key, cli, value, description, opts)
   return self
 end
 
+---@param heading string Heading to render within config section of popup
+---@return self
 function M:config_heading(heading)
   table.insert(self.state.config, { heading = heading })
   return self
 end
 
+---@param key string Key for user to use that engages config
+---@param name string Name of config
+---@param options table|nil
+---@param options.options table Table of tables, each consisting of `{ display = "", value = "" }`
+--                              where 'display' is what is shown to the user, and 'value' is what gets used by the cli.
+--                              A 'condition' key with function value can also be present in the option, which controls if the option gets shown by returning boolean.
+---@param options.passive boolean Controls if this config setting can be manipulated directly, or if it is managed by git, and should just be shown in UI
+---@param 
+---@return self
 function M:config(key, name, options)
   local c = config.get(name) or { value = "" }
 
@@ -182,6 +238,10 @@ function M:config(key, name, options)
   return self
 end
 
+-- Conditionally adds config to popup
+---@see M:config
+---@param cond boolean
+---@return self
 function M:config_if(cond, key, name, options)
   if cond then
     return self:config(key, name, options)
@@ -190,6 +250,11 @@ function M:config_if(cond, key, name, options)
   return self
 end
 
+
+---@param key string Key for user to hit that runs action
+---@param description string Description of action in UI
+---@param callback function Function that gets run in async context
+---@return self
 function M:action(key, description, callback)
   if not self.state.keys[key] then
     table.insert(self.state.actions[#self.state.actions], {
@@ -204,6 +269,10 @@ function M:action(key, description, callback)
   return self
 end
 
+-- Conditionally adds action to popup
+---@param cond boolean
+---@see M:action
+---@return self
 function M:action_if(cond, key, description, callback)
   if cond then
     return self:action(key, description, callback)

--- a/lua/neogit/lib/popup/builder.lua
+++ b/lua/neogit/lib/popup/builder.lua
@@ -216,7 +216,6 @@ end
 --                              where 'display' is what is shown to the user, and 'value' is what gets used by the cli.
 --                              A 'condition' key with function value can also be present in the option, which controls if the option gets shown by returning boolean.
 ---@param options.passive boolean Controls if this config setting can be manipulated directly, or if it is managed by git, and should just be shown in UI
----@param 
 ---@return self
 function M:config(key, name, options)
   local c = config.get(name) or { value = "" }
@@ -249,7 +248,6 @@ function M:config_if(cond, key, name, options)
 
   return self
 end
-
 
 ---@param key string Key for user to hit that runs action
 ---@param description string Description of action in UI


### PR DESCRIPTION
I thought it would be easier for these to stand in their own PR.

`popup`
- Rename `option.parse` to `option.internal` (parse made no sense)
- Add `arg.cli_prefix` since some git flags do not use `--`. Some use `++`. Some use a single `-`. It's wild.
- Add `config` type to popups. This is, you guessed it, a `git config` setting the user can change.
- Switches can now be incompatible with other switches (defined in the popup creator) to prevent invalid input states
- `option`s can now support a `choices` table, to restrict the user to a set of valid inputs
- Adds a 'heading' value to allow for different categories of actions

`builder`
- Combine `self.state.switches` and `self.state.options` to `self.state.args` so we have better control over placement and ordering, and can set more detailed headings for sections. The existing layout style (options and switches) can be maintained, but it allow much greater flexibility.
- add `new_action_group_if` for conditional version
- Add `group_heading` and `group_heading_if` to set the heading for an action group
- Add switch opts:
  - internal (renamed from 'parse')
  - incompatible - prevent bad input state with a list of mutually exclusive switches
  - key_prefix - add the ability to overwrite the default hotkey prefix, `-` with something else
  - cli_prefix - Some switches (from the UI) are _not_ switches to the cli, so we need to account for that
  - value - allow setting a default value. Note, this is distinct from an option, where the value has a `=` separating it from the flag. Git log, for example, lets you send `-Gsomething` where `something` is user input.
- Add option opts:
  - key_prefix - same as switch
  - cli_prefix - same as switch
  - choices - limit user to prespecified choices (selected using `vim.ui.select`)
  - default - a default value
- arg_heading - Adds section heading for arguments
- config_heading - adds section heading for config

Here are some screenshots for what these changes allow:
`Log Popup`
![Screenshot 2023-05-15 at 15 49 18](https://github.com/TimUntersberger/neogit/assets/7228095/1fbc86db-3947-43d8-b342-ed26ddacaa2b)

`Commit Popup`
![Screenshot 2023-05-15 at 15 49 52](https://github.com/TimUntersberger/neogit/assets/7228095/cfd06f59-1813-4782-b573-1a332ff3fad5)

`Rebase Popup`
![Screenshot 2023-05-15 at 15 49 58](https://github.com/TimUntersberger/neogit/assets/7228095/0084794c-88d5-477f-b63e-7b4668d0c60f)

`Pull Popup`
![Screenshot 2023-05-15 at 15 50 06](https://github.com/TimUntersberger/neogit/assets/7228095/2dda6e25-a8de-4e57-879d-ae69a52041d3)

`Branch Popup`
![Screenshot 2023-05-15 at 15 58 15](https://github.com/TimUntersberger/neogit/assets/7228095/c157e8ff-c3cd-465a-b455-078cadfd3234)

`Branch Config Popup`
![Screenshot 2023-05-15 at 16 23 30](https://github.com/TimUntersberger/neogit/assets/7228095/e61300e0-927c-4aed-af14-45a4bfa493b2)
