### PR TITLE
fix: no blank line at the end of file for git 2.39

### DIFF
--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -16,10 +16,10 @@ local old_config
 
 local function remove_trailing_blankline(lines)
   if lines[#lines] ~= "" then
-    error("Git show did not end with a blankline")
+    lines[#lines + 1] = nil
+  else
+    lines[#lines] = nil
   end
-
-  lines[#lines] = nil
   return lines
 end
 


### PR DESCRIPTION
OS: Darwin 22.5.0 arm64
Git: git version 2.39.2 (Apple Git-143)

diff file in diffview got the following error:
```
[ERROR 2023-06-19 10:47:27.415 +0800] ...re/nvim/lazy/diffview.nvim/lua/diffview/scene/window.lua:102: ...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:179: The coroutine failed with this message: 
	context: cur_thread=<thread 0x0105a85f38> co_thread=<thread 0x0105a86b70> co_func=.../share/nvim/lazy/diffview.nvim/lua/diffview/vcs/file.lua:193
...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:179: The coroutine failed with this message: 
	context: cur_thread=<thread 0x0105a86b70> co_thread=<thread 0x0105a94888> co_func=.../share/nvim/lazy/diffview.nvim/lua/diffview/vcs/file.lua:174
...re/nvim/lazy/neogit/lua/neogit/integrations/diffview.lua:20: Git show did not end with a blankline
stack traceback:
	[C]: in function 'error'
	...re/nvim/lazy/neogit/lua/neogit/integrations/diffview.lua:20: in function 'remove_trailing_blankline'
	...re/nvim/lazy/neogit/lua/neogit/integrations/diffview.lua:129: in function 'get_data'
	.../share/nvim/lazy/diffview.nvim/lua/diffview/vcs/file.lua:177: in function <.../share/nvim/lazy/diffview.nvim/lua/diffview/vcs/file.lua:174>
	[C]: in function 'xpcall'
	...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:354: in function <...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:351>
stack traceback:
	[C]: in function 'error'
	...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:362: in function <...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:351>
stack traceback:
	[C]: in function 'error'
	...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:179: in function 'raise'
	...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:207: in function 'step'
	...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:405: in function 'produce_data'
	.../share/nvim/lazy/diffview.nvim/lua/diffview/vcs/file.lua:245: in function <.../share/nvim/lazy/diffview.nvim/lua/diffview/vcs/file.lua:193>
	[C]: in function 'xpcall'
	...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:354: in function <...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:351>
stack traceback:
	[C]: in function 'error'
	...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:362: in function <...cal/share/nvim/lazy/diffview.nvim/lua/diffview/async.lua:351>
[ERROR 2023-06-19 10:47:27.415 +0800] ...cal/share/nvim/lazy/diffview.nvim/lua/diffview/utils.lua:92: Failed to create diff buffer: ':0:src/main/...File.java'

```

seems this version of git dosen't output a blank line at the end of the file